### PR TITLE
[feat] 1.5차 스프린트 api 연동

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -22,6 +22,8 @@ export async function reissueTokens(tokens: Tokens): Promise<Tokens> {
 
   const newRefreshToken = response.headers.get('refresh-token') ?? '';
 
+  console.log('리이슈 토큰', newAccessToken);
+
   // 3) 쿠키에 저장 (브라우저 측)
   setCookie('accessToken', newAccessToken, { path: '/' });
   setCookie('refreshToken', newRefreshToken, { path: '/' });

--- a/apps/web/src/api/fetch.ts
+++ b/apps/web/src/api/fetch.ts
@@ -23,7 +23,7 @@ async function fetchWrapperWithTokenHandler<Data>(
 ): Promise<ApiResponse<Data>> {
   const method = options?.method ?? 'get';
 
-  //console.log('토큰', tokens);
+  console.log('토큰', tokens);
 
   // 클라이언트 사이드에서 토큰이 없으면 쿠키에서 읽어옴
   if (!tokens && typeof window !== 'undefined') {

--- a/apps/web/src/api/fetch.ts
+++ b/apps/web/src/api/fetch.ts
@@ -134,9 +134,14 @@ export function PUT<Data>(
 /** DELETE 요청 */
 export function DELETE<Data>(
   uri: string,
+  body?: unknown,
   tokens?: Tokens
 ): Promise<ApiResponse<Data>> {
-  return fetchWrapperWithTokenHandler<Data>(uri, { method: 'delete' }, tokens);
+  return fetchWrapperWithTokenHandler<Data>(
+    uri,
+    { method: 'delete', json: body },
+    tokens
+  );
 }
 
 /** PATCH 요청 */

--- a/apps/web/src/app/(main)/organization/@modal/(.)invite/page.tsx
+++ b/apps/web/src/app/(main)/organization/@modal/(.)invite/page.tsx
@@ -3,12 +3,12 @@
 import { useRouter } from 'next/navigation';
 import { Modal } from '@repo/ui/Modal';
 import InviteContent from '../../_components/InviteModal/InviteContent';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState, KeyboardEvent } from 'react';
 import { INITIAL_SELECTED } from '@web/constants/organization';
 import { User } from '@web/types/organization';
 import InviteHeader from '../../_components/InviteModal/InviteHeader';
-import { Toast } from '@repo/ui/Toast';
 import { useToast } from '@repo/ui/hooks';
+import { useUserByEmailQuery } from '@web/store/query/useUserByEmailQuery';
 
 export default function InviteModal() {
   const router = useRouter();
@@ -16,12 +16,36 @@ export default function InviteModal() {
 
   // 상태: 검색어 & 선택된 유저 목록
   const [search, setSearch] = useState('');
-  const [selected, setSelected] = useState<User[]>(INITIAL_SELECTED);
+  const [selected, setSelected] = useState<User[]>([]);
   const toast = useToast();
+
+  // 이메일로 유저 조회
+  const { data, refetch, isFetching } = useUserByEmailQuery(search, false);
 
   // 검색어 변경 핸들러
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
+  };
+
+  const handleSearchKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && search.trim()) {
+      const res = await refetch();
+      if (res.data) {
+        const u = res.data;
+        const ui: User = {
+          id: String(u.userId),
+          name: u.name,
+          email: u.email,
+          profileUrl: u.imageUrl ?? '',
+        };
+        setSelected((prev) =>
+          prev.some((x) => x.id === ui.id) ? prev : [...prev, ui]
+        );
+        setSearch('');
+      } else {
+        toast.error('해당 이메일의 사용자를 찾을 수 없습니다.', 3000);
+      }
+    }
   };
 
   // 선택 해제 핸들러
@@ -48,6 +72,7 @@ export default function InviteModal() {
               onSearchChange={handleSearchChange}
               selected={selected}
               onRemove={handleRemove}
+              onSearchKeyDown={handleSearchKeyDown}
             />
           </Modal.Content>
           <Modal.Footer hasTopBorder>

--- a/apps/web/src/app/(main)/organization/OrganizationPageClient.tsx
+++ b/apps/web/src/app/(main)/organization/OrganizationPageClient.tsx
@@ -1,4 +1,3 @@
-// app/organization/OrganizationPageClient.tsx
 'use client';
 import { useState, useMemo, ChangeEvent } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -18,7 +17,6 @@ import { Flex } from '@repo/ui/Flex';
 import { Breadcrumb } from '@repo/ui/Breadcrumb';
 import * as styles from './page.css';
 
-// 서버에서 미리 받아온 페이지 크기
 const PAGE_SIZE = 20;
 
 interface Props {
@@ -36,7 +34,7 @@ export default function OrganizationPageClient({
   const { confirm } = useModal();
   const qc = useQueryClient();
 
-  // 1) 멤버 리스트(서버)
+  // 멤버 리스트
   const { data: paged, isFetching } = useOrganizationMembersQuery(
     organizationId,
     page,
@@ -45,7 +43,7 @@ export default function OrganizationPageClient({
   const members = paged?.content ?? [];
   const totalCount = paged?.totalElements ?? 0;
 
-  // 2) 역할 리스트(서버)
+  // 역할 리스트
   const { data: rolesData } = useOrganizationRolesQuery(organizationId);
   const allRoles = rolesData.roles.map((r) => ({
     label: r.roleName,
@@ -53,21 +51,21 @@ export default function OrganizationPageClient({
     id: r.id,
   }));
 
-  // 3) 삭제 뮤테이션
+  // 삭제
   const deleteMutation = useDeleteOrganizationUsersMutation(
     organizationId,
     page,
     PAGE_SIZE
   );
 
-  // 4) 단일 역할 부여 뮤테이션
+  // 단일 역할 부여
   const assignRoleMutation = useAssignRoleToUserMutation(
     organizationId,
     page,
     PAGE_SIZE
   );
 
-  // 5) 선택 토글
+  // 선택 토글
   const handleToggleOne = (id: string, checked: boolean) =>
     setSelectedIds((prev) =>
       checked ? [...prev, id] : prev.filter((x) => x !== id)
@@ -79,12 +77,12 @@ export default function OrganizationPageClient({
     members.length > 0 &&
     members.every((m) => selectedIds.includes(String(m.userId)));
 
-  // 6) 배너 토글
+  // 배너 토글
   const showBanner =
     selectedIds.length > 0 &&
     (isAllPageSelected || selectedIds.length === totalCount);
 
-  // 7) 삭제 실행
+  // 삭제
   const handleDeleteClick = () => {
     confirm({
       type: 'warning',
@@ -98,12 +96,12 @@ export default function OrganizationPageClient({
     });
   };
 
-  // 8) 역할 부여
+  // 역할 부여
   const handleAddRole = (memberId: string, role: { id: number }) => {
     assignRoleMutation.mutate({ userId: Number(memberId), roleIds: [role.id] });
   };
 
-  // 9) 필터링 + 페이징
+  // 필터링 + 페이징
   const filtered = useMemo(
     () =>
       members.filter((m) =>
@@ -158,14 +156,11 @@ export default function OrganizationPageClient({
         />
         <OrgList
           data={filtered.map((m) => ({
-            // —— Member 필수 프로퍼티만 골라내기 ——
             id: String(m.userId),
             name: m.name,
             email: m.email,
             profileUrl: m.profileImageUrl ?? '',
 
-            // 서버에서 넘어온 roles: { id, roleName, colorName }
-            // ↓ UI 에선 Role = { id, label, color: TagColor } 이므로
             roles: m.roles.map((r) => ({
               id: r.id,
               label: r.roleName,
@@ -180,7 +175,6 @@ export default function OrganizationPageClient({
           selectedIds={selectedIds}
           onToggleAll={handleToggleAll}
           onToggleOne={handleToggleOne}
-          // availableRoles 도 똑같이 id,label,color 로만
           availableRoles={rolesData.roles.map((r) => ({
             id: r.id,
             label: r.roleName,

--- a/apps/web/src/app/(main)/organization/OrganizationPageClient.tsx
+++ b/apps/web/src/app/(main)/organization/OrganizationPageClient.tsx
@@ -1,165 +1,207 @@
+// app/organization/OrganizationPageClient.tsx
 'use client';
-import { useState, ChangeEvent, useMemo } from 'react';
-import { Member, Role } from '@web/types/organization';
+import { useState, useMemo, ChangeEvent } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Text } from '@repo/ui/Text';
 import OrgSearchToolbar from './_components/OrgSearchToolbar/OrgSearchToolbar';
+import OrgList from './_components/OrgList/OrgList';
+import SelectionNotification from './_components/SelectionNotification/SelectionNotification';
 import { Pagination } from '@repo/ui/Pagination';
+import { useModal } from '@repo/ui/hooks';
+import { useOrganizationMembersQuery } from '@web/store/query/useOrganizationMembersQuery';
+import { useOrganizationRolesQuery } from '@web/store/query/useOrganizationRolesQuery';
+import { useDeleteOrganizationUsersMutation } from '@web/store/mutation/useDeleteOrganizationUsersMutation';
+import { useAssignRoleToUserMutation } from '@web/store/mutation/useAssignRoleToUserMutation';
+import { mapServerColorToTagHex } from '@web/utils/color';
+import InviteModal from './@modal/(.)invite/page';
 import { Flex } from '@repo/ui/Flex';
 import { Breadcrumb } from '@repo/ui/Breadcrumb';
-import { Text } from '@repo/ui/Text';
 import * as styles from './page.css';
-import OrgList from './_components/OrgList/OrgList';
-import { useModal } from '@repo/ui/hooks';
-import SelectionNotification from './_components/SelectionNotification/SelectionNotification';
 
-// 목데이터 + 전체 가능한 역할 목록
-const INITIAL_MEMBERS: Member[] = Array.from({ length: 38 }, (_, i) => ({
-  id: String(i + 1).padStart(3, '0'),
-  name: '김현호',
-  email: 'rable8264@gmail.com',
-  roles: [{ label: '프론트엔드', color: '#E2A500' }],
-  gender: '남',
-  dob: '2001.01.16',
-  phone: '010-3940-5094',
-  joined: '2025.04.18',
-  profileUrl:
-    'https://image.dongascience.com/Photo/2020/03/5bddba7b6574b95d37b6079c199d7101.jpg',
-}));
+// 서버에서 미리 받아온 페이지 크기
+const PAGE_SIZE = 20;
 
-const ALL_ROLES: Role[] = [
-  { label: '기획', color: '#FF2A3A' },
-  { label: '디자인', color: '#EE6B00' },
-  { label: '백엔드', color: '#E2A500' },
-  { label: '프론트엔드', color: '#E2A500' },
-  { label: '부학회장', color: '#009857' },
-  { label: '학회장', color: '#813DFF' },
-];
+interface Props {
+  organizationId: number;
+  showInvite: boolean;
+}
 
-export default function OrganizationPageClient() {
-  const [members, setMembers] = useState<Member[]>(INITIAL_MEMBERS);
+export default function OrganizationPageClient({
+  organizationId,
+  showInvite,
+}: Props) {
   const [search, setSearch] = useState('');
-  const [currentPage, setCurrentPage] = useState(1);
-  const { confirm } = useModal();
-  // 필터 + 페이징
-  const filtered = useMemo(() => {
-    return members.filter((m) =>
-      m.name.toLowerCase().includes(search.toLowerCase())
-    );
-  }, [members, search]);
-
-  const perPage = 20;
-  const start = (currentPage - 1) * perPage;
-
-  const pageData = useMemo(() => {
-    return filtered.slice(start, start + perPage);
-  }, [filtered, start]);
-
+  const [page, setPage] = useState(1);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const { confirm } = useModal();
+  const qc = useQueryClient();
 
-  // 배너 표시 여부 계산
-  const isPageOnly = selectedIds.length === pageData.length;
-  const isAll = selectedIds.length === filtered.length;
-  const showBanner = selectedIds.length > 0 && (isPageOnly || isAll);
+  // 1) 멤버 리스트(서버)
+  const { data: paged, isFetching } = useOrganizationMembersQuery(
+    organizationId,
+    page,
+    PAGE_SIZE
+  );
+  const members = paged?.content ?? [];
+  const totalCount = paged?.totalElements ?? 0;
 
-  // 전체 페이지 토글 핸들러
-  const handleToggleScope = () => {
-    if (isAll) {
-      // 전체 → 페이지만
-      setSelectedIds(pageData.map((m) => m.id));
-    } else {
-      // 페이지 → 전체
-      setSelectedIds(filtered.map((m) => m.id));
-    }
-  };
+  // 2) 역할 리스트(서버)
+  const { data: rolesData } = useOrganizationRolesQuery(organizationId);
+  const allRoles = rolesData.roles.map((r) => ({
+    label: r.roleName,
+    color: r.color,
+    id: r.id,
+  }));
 
-  // 체크박스
-  const handleToggleAll = (checked: boolean) =>
-    setSelectedIds(checked ? pageData.map((m) => m.id) : []);
+  // 3) 삭제 뮤테이션
+  const deleteMutation = useDeleteOrganizationUsersMutation(
+    organizationId,
+    page,
+    PAGE_SIZE
+  );
+
+  // 4) 단일 역할 부여 뮤테이션
+  const assignRoleMutation = useAssignRoleToUserMutation(
+    organizationId,
+    page,
+    PAGE_SIZE
+  );
+
+  // 5) 선택 토글
   const handleToggleOne = (id: string, checked: boolean) =>
     setSelectedIds((prev) =>
       checked ? [...prev, id] : prev.filter((x) => x !== id)
     );
+  const handleToggleAll = (checked: boolean) =>
+    setSelectedIds(checked ? members.map((m) => String(m.userId)) : []);
 
-  // 역할 추가
-  const handleAddRole = (memberId: string, role: Role) => {
-    setMembers((prev) =>
-      prev.map((m) =>
-        m.id === memberId
-          ? {
-              ...m,
-              roles: [...m.roles.filter((r) => r.label !== role.label), role],
-            }
-          : m
-      )
-    );
-  };
-  // 삭제 클릭 시
+  const isAllPageSelected =
+    members.length > 0 &&
+    members.every((m) => selectedIds.includes(String(m.userId)));
+
+  // 6) 배너 토글
+  const showBanner =
+    selectedIds.length > 0 &&
+    (isAllPageSelected || selectedIds.length === totalCount);
+
+  // 7) 삭제 실행
   const handleDeleteClick = () => {
     confirm({
       type: 'warning',
-      title: `${selectedIds.length}명의 멤버를 삭제하시겠습니까?`,
+      title: `${selectedIds.length}명을 정말 삭제하시겠습니까?`,
       cancelText: '취소',
       confirmText: '삭제',
       onConfirm: () => {
-        // 실제 삭제 로직 추가하기!
-        //setMembers((prev) => prev.filter((m) => !selectedIds.includes(m.id)));
-        //setSelectedIds([]);
+        deleteMutation.mutate({ userIds: selectedIds.map(Number) });
+        setSelectedIds([]);
       },
     });
   };
 
-  return (
-    <Flex direction="column">
-      <Flex direction="column" gap="1.8rem" marginBottom="1.8rem" width="100%">
-        <Flex align="center" justify="spaceBetween" width="100%">
-          <Breadcrumb>
-            <Breadcrumb.Item active>조직 관리</Breadcrumb.Item>
-          </Breadcrumb>
+  // 8) 역할 부여
+  const handleAddRole = (memberId: string, role: { id: number }) => {
+    assignRoleMutation.mutate({ userId: Number(memberId), roleIds: [role.id] });
+  };
 
-          {showBanner && (
-            <SelectionNotification
-              pageCount={pageData.length}
-              totalCount={filtered.length}
-              isAllSelected={isAll}
-              onToggleScope={handleToggleScope}
-            />
-          )}
+  // 9) 필터링 + 페이징
+  const filtered = useMemo(
+    () =>
+      members.filter((m) =>
+        m.name.toLowerCase().includes(search.toLowerCase())
+      ),
+    [members, search]
+  );
+
+  return (
+    <>
+      {showInvite && <InviteModal />}
+      <Flex direction="column">
+        <Flex
+          direction="column"
+          gap="1.8rem"
+          marginBottom="1.8rem"
+          width="100%"
+        >
+          <Flex align="center" justify="spaceBetween" width="100%">
+            <Breadcrumb>
+              <Breadcrumb.Item active>조직 관리</Breadcrumb.Item>
+            </Breadcrumb>
+            {showBanner && (
+              <SelectionNotification
+                pageCount={filtered.length}
+                totalCount={totalCount}
+                isAllSelected={selectedIds.length === totalCount}
+                onToggleScope={() =>
+                  setSelectedIds(
+                    selectedIds.length === totalCount
+                      ? filtered.map((m) => String(m.userId))
+                      : filtered.map((m) => String(m.userId))
+                  )
+                }
+              />
+            )}
+          </Flex>
+
+          <Text variant="xl_title_semibold" color="black">
+            조직 관리
+          </Text>
         </Flex>
 
-        <Text variant="xl_title_semibold" color="black">
-          조직 관리
-        </Text>
-      </Flex>
-
-      <OrgSearchToolbar
-        search={search}
-        onSearchChange={(e: ChangeEvent<HTMLInputElement>) => {
-          setSearch(e.target.value);
-          setCurrentPage(1);
-        }}
-        selectedCount={selectedIds.length}
-        totalCount={filtered.length}
-        onDelete={handleDeleteClick}
-      />
-
-      <OrgList
-        search={search}
-        data={pageData}
-        selectedIds={selectedIds}
-        onToggleAll={handleToggleAll}
-        onToggleOne={handleToggleOne}
-        availableRoles={ALL_ROLES}
-        onAddRole={handleAddRole}
-      />
-
-      <div className={styles.paginationStyle}>
-        <Pagination
-          totalItems={filtered.length}
-          itemCountPerPage={perPage}
-          pageCount={8}
-          currentPage={currentPage}
-          onPageChange={(p) => setCurrentPage(p)}
+        <OrgSearchToolbar
+          search={search}
+          onSearchChange={(e: ChangeEvent<HTMLInputElement>) => {
+            setSearch(e.target.value);
+          }}
+          selectedCount={selectedIds.length}
+          totalCount={totalCount}
+          onDelete={handleDeleteClick}
         />
-      </div>
-    </Flex>
+        <OrgList
+          data={filtered.map((m) => ({
+            // —— Member 필수 프로퍼티만 골라내기 ——
+            id: String(m.userId),
+            name: m.name,
+            email: m.email,
+            profileUrl: m.profileImageUrl ?? '',
+
+            // 서버에서 넘어온 roles: { id, roleName, colorName }
+            // ↓ UI 에선 Role = { id, label, color: TagColor } 이므로
+            roles: m.roles.map((r) => ({
+              id: r.id,
+              label: r.roleName,
+              color: mapServerColorToTagHex(r.color),
+            })),
+
+            gender: m.gender,
+            dob: m.birthDate,
+            phone: m.phoneNumber,
+            joined: m.createdAt.replace('.', '/'),
+          }))}
+          selectedIds={selectedIds}
+          onToggleAll={handleToggleAll}
+          onToggleOne={handleToggleOne}
+          // availableRoles 도 똑같이 id,label,color 로만
+          availableRoles={rolesData.roles.map((r) => ({
+            id: r.id,
+            label: r.roleName,
+            color: mapServerColorToTagHex(r.color),
+          }))}
+          onAddRole={handleAddRole}
+          search={search}
+        />
+        <div className={styles.paginationStyle}>
+          <Pagination
+            currentPage={page + 1}
+            totalItems={totalCount}
+            itemCountPerPage={PAGE_SIZE}
+            pageCount={5}
+            onPageChange={(p) => {
+              setPage(p - 1);
+              setSelectedIds([]);
+            }}
+          />
+        </div>
+      </Flex>
+    </>
   );
 }

--- a/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
+++ b/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
@@ -2,8 +2,9 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
-import OrganizationPageClient from '../OrganizationPageClient';
+
 import InviteModal from '../@modal/(.)invite/page';
+import OrganizationPageClient from '../OrganizationPageClient';
 
 export default function Page() {
   // URL이 /organization/invite 면 modal = ['invite']

--- a/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
+++ b/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
@@ -1,20 +1,44 @@
-'use client';
-
-import React from 'react';
-import { useParams } from 'next/navigation';
-
-import InviteModal from '../@modal/(.)invite/page';
+// app/organization/[...modal]/page.tsx
+import { getServerSideTokens } from '@web/api/serverSideTokens';
+import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
+import { getOrganizationMembersQueryOptions } from '@web/store/query/useOrganizationMembersQuery';
+import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
 import OrganizationPageClient from '../OrganizationPageClient';
 
-export default function Page() {
-  // URL이 /organization/invite 면 modal = ['invite']
-  const { modal } = useParams() as { modal?: string[] };
-  const showInvite = modal?.[0] === 'invite';
+// Next.js App Router 에선 params 를 이렇게 받습니다.
+export default async function Page({
+  params,
+}: {
+  params: { modal?: string[] };
+}) {
+  const tokens = await getServerSideTokens();
+  const organizationId = 3;
+
+  const roleFetchOptions = getOrganizationRolesQueryOptions({
+    organizationId,
+    tokens,
+  });
+  const membersFetchOptions = getOrganizationMembersQueryOptions({
+    organizationId,
+    page: 1,
+    size: 20,
+    tokens,
+  });
+
+  // URL이 /organization/(invite) 형태면 modal = ['invite']
+  const showInvite = params.modal?.[0] === 'invite';
 
   return (
     <>
-      <OrganizationPageClient />
-      {showInvite && <InviteModal />}
+      <ServerFetchBoundary fetchOptions={[roleFetchOptions]}>
+        <ServerFetchBoundary fetchOptions={[membersFetchOptions]}>
+          {/* 클라이언트 컴포넌트에 server→client로 props 전달 */}
+          <OrganizationPageClient
+            organizationId={organizationId}
+            showInvite={showInvite}
+          />
+        </ServerFetchBoundary>
+      </ServerFetchBoundary>
     </>
   );
 }

--- a/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
+++ b/apps/web/src/app/(main)/organization/[[...modal]]/page.tsx
@@ -1,15 +1,13 @@
-// app/organization/[...modal]/page.tsx
 import { getServerSideTokens } from '@web/api/serverSideTokens';
 import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
 import { getOrganizationMembersQueryOptions } from '@web/store/query/useOrganizationMembersQuery';
 import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
 import OrganizationPageClient from '../OrganizationPageClient';
 
-// Next.js App Router 에선 params 를 이렇게 받습니다.
 export default async function Page({
   params,
 }: {
-  params: { modal?: string[] };
+  params: Promise<{ modal?: string[] }>;
 }) {
   const tokens = await getServerSideTokens();
   const organizationId = 3;
@@ -25,14 +23,13 @@ export default async function Page({
     tokens,
   });
 
-  // URL이 /organization/(invite) 형태면 modal = ['invite']
-  const showInvite = params.modal?.[0] === 'invite';
+  const { modal } = await params;
+  const showInvite = modal?.[0] === 'invite';
 
   return (
     <>
       <ServerFetchBoundary fetchOptions={[roleFetchOptions]}>
         <ServerFetchBoundary fetchOptions={[membersFetchOptions]}>
-          {/* 클라이언트 컴포넌트에 server→client로 props 전달 */}
           <OrganizationPageClient
             organizationId={organizationId}
             showInvite={showInvite}

--- a/apps/web/src/app/(main)/organization/_components/InviteModal/InviteContent.tsx
+++ b/apps/web/src/app/(main)/organization/_components/InviteModal/InviteContent.tsx
@@ -2,13 +2,14 @@ import { InputField } from '@repo/ui/InputField';
 import * as styles from './InviteModal.css';
 import { IcInputSearch } from '@repo/ui/icons/colored';
 import { Flex } from '@repo/ui/Flex';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, KeyboardEvent } from 'react';
 import SelectedUserItem from './SelectedUserItem';
 import { User } from '@web/types/organization';
 
 export type InviteContentProps = {
   search: string;
   onSearchChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSearchKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   selected: User[];
   onRemove: (id: string) => void;
 };
@@ -18,6 +19,7 @@ export default function InviteContent({
   onSearchChange,
   selected,
   onRemove,
+  onSearchKeyDown,
 }: InviteContentProps) {
   return (
     <Flex direction="column" gap="1.2rem" width="100%">
@@ -27,6 +29,7 @@ export default function InviteContent({
         value={search}
         icon={<IcInputSearch width={24} height={24} />}
         onChange={onSearchChange}
+        onKeyDown={onSearchKeyDown}
         width="100%"
         size="search"
       />

--- a/apps/web/src/app/(main)/organization/_components/InviteModal/InviteModal.css.ts
+++ b/apps/web/src/app/(main)/organization/_components/InviteModal/InviteModal.css.ts
@@ -15,6 +15,7 @@ export const listContainer = style({
   flexDirection: 'column',
   gap: '0.8rem',
   width: '100%',
+  height: '32.2rem',
   maxHeight: '32.2rem',
   overflowY: 'scroll',
 

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberAssignmentPanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberAssignmentPanel.tsx
@@ -1,4 +1,3 @@
-// src/app/(main)/settings/_components/MemberAssignmentPanel.tsx
 'use client';
 
 import React, { useState, ChangeEvent } from 'react';

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberAssignmentPanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberAssignmentPanel.tsx
@@ -1,18 +1,19 @@
+// src/app/(main)/settings/_components/MemberAssignmentPanel.tsx
 'use client';
 
 import React, { useState, ChangeEvent } from 'react';
 import { Text } from '@repo/ui/Text';
 import { SearchInput } from '@repo/ui/SearchInput';
 import MemberPanel from './MemberPanel';
-import { User } from '@web/types/organization';
+import type { UserResult } from '@web/types/organization';
 import * as styles from './MemberAssignmentPanel.css';
 import { IcDeleteRight, IcPlusLeft } from '@repo/ui/icons/mono';
 
 interface Props {
-  addedMembers: User[];
-  availableMembers: User[];
-  onAdd: (u: User) => void;
-  onRemove: (u: User) => void;
+  addedMembers: UserResult[];
+  availableMembers: UserResult[];
+  onAdd: (u: UserResult) => void;
+  onRemove: (u: UserResult) => void;
 }
 
 export default function MemberAssignmentPanel({
@@ -22,8 +23,8 @@ export default function MemberAssignmentPanel({
   onRemove,
 }: Props) {
   const [search, setSearch] = useState('');
-  const [selAdded, setSelAdded] = useState<Set<string>>(new Set());
-  const [selAvail, setSelAvail] = useState<Set<string>>(new Set());
+  const [selAdded, setSelAdded] = useState<Set<number>>(new Set());
+  const [selAvail, setSelAvail] = useState<Set<number>>(new Set());
 
   const filteredAdded = addedMembers.filter((u) =>
     u.name.toLowerCase().includes(search.toLowerCase())
@@ -33,31 +34,20 @@ export default function MemberAssignmentPanel({
   );
 
   const allAdded =
-    filteredAdded.length > 0 && filteredAdded.every((u) => selAdded.has(u.id));
+    filteredAdded.length > 0 &&
+    filteredAdded.every((u) => selAdded.has(u.userId));
   const allAvail =
-    filteredAvail.length > 0 && filteredAvail.every((u) => selAvail.has(u.id));
+    filteredAvail.length > 0 &&
+    filteredAvail.every((u) => selAvail.has(u.userId));
 
   const toggleSet = (
-    set: Set<string>,
-    setFn: React.Dispatch<Set<string>>,
-    id: string
+    set: Set<number>,
+    setFn: React.Dispatch<Set<number>>,
+    id: number
   ) => {
     const nxt = new Set(set);
     nxt.has(id) ? nxt.delete(id) : nxt.add(id);
     setFn(nxt);
-  };
-
-  const toggleAdded = (id: string) => toggleSet(selAdded, setSelAdded, id);
-  const toggleAvail = (id: string) => toggleSet(selAvail, setSelAvail, id);
-
-  const selectAllAdded = () => {
-    if (allAdded) setSelAdded(new Set());
-    else setSelAdded(new Set(filteredAdded.map((u) => u.id)));
-  };
-
-  const selectAllAvail = () => {
-    if (allAvail) setSelAvail(new Set());
-    else setSelAvail(new Set(filteredAvail.map((u) => u.id)));
   };
 
   return (
@@ -78,38 +68,47 @@ export default function MemberAssignmentPanel({
       <div className={styles.panels}>
         <MemberPanel
           title="추가된 멤버"
-          count={addedMembers.length}
+          count={filteredAdded.length}
           items={filteredAdded}
           selected={selAdded}
           allSelected={allAdded}
-          onToggleAll={selectAllAdded}
+          onToggleAll={() =>
+            setSelAdded(
+              allAdded ? new Set() : new Set(filteredAdded.map((u) => u.userId))
+            )
+          }
           onAction={() => {
             filteredAdded.forEach((u) => {
-              if (selAdded.has(u.id)) onRemove(u);
+              if (selAdded.has(u.userId)) onRemove(u);
             });
             setSelAdded(new Set());
           }}
           actionLabel="제외"
           actionIcon={<IcDeleteRight />}
-          onToggleItem={toggleAdded}
+          onToggleItem={(id) => toggleSet(selAdded, setSelAdded, id)}
           search={search}
         />
+
         <MemberPanel
           title="추가하지 않은 멤버"
-          count={availableMembers.length}
+          count={filteredAvail.length}
           items={filteredAvail}
           selected={selAvail}
           allSelected={allAvail}
-          onToggleAll={selectAllAvail}
+          onToggleAll={() =>
+            setSelAvail(
+              allAvail ? new Set() : new Set(filteredAvail.map((u) => u.userId))
+            )
+          }
           onAction={() => {
             filteredAvail.forEach((u) => {
-              if (selAvail.has(u.id)) onAdd(u);
+              if (selAvail.has(u.userId)) onAdd(u);
             });
             setSelAvail(new Set());
           }}
           actionLabel="추가"
           actionIcon={<IcPlusLeft />}
-          onToggleItem={toggleAvail}
+          onToggleItem={(id) => toggleSet(selAvail, setSelAvail, id)}
           search={search}
         />
       </div>

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberListItem.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberListItem.tsx
@@ -1,4 +1,3 @@
-// src/app/(main)/settings/_components/MemberListItem.tsx
 import React from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { CheckBox } from '@repo/ui/CheckBox';

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberListItem.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberListItem.tsx
@@ -1,13 +1,14 @@
+// src/app/(main)/settings/_components/MemberListItem.tsx
 import React from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { CheckBox } from '@repo/ui/CheckBox';
 import { Profile } from '@repo/ui/Profile';
 import { Text } from '@repo/ui/Text';
+import type { UserResult } from '@web/types/organization';
 import * as styles from './MemberAssignmentPanel.css';
-import { User } from '@web/types/organization';
 
 interface Props {
-  user: User;
+  user: UserResult;
   isSelected: boolean;
   onToggle: () => void;
   search: string;
@@ -32,7 +33,7 @@ export default function MemberListItem({
       <div style={{ marginRight: '0.4rem', height: '2rem', width: '2rem' }}>
         <CheckBox size={2} isChecked={isSelected} onChange={onToggle} />
       </div>
-      <Profile src={user.profileUrl!} alt={user.name} size={24} />
+      <Profile src={user.imageUrl ?? null} alt={user.name} size={24} />
       <Text variant="sm_caption_regular" color="grayscale90">
         {nameParts.map((part, idx) =>
           search && part.toLowerCase() === search.toLowerCase() ? (

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberPanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberPanel.tsx
@@ -1,24 +1,24 @@
+// src/app/(main)/settings/_components/MemberPanel.tsx
 import React, { ReactElement } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { Text } from '@repo/ui/Text';
 import { CheckBox } from '@repo/ui/CheckBox';
 import { Button } from '@repo/ui/Button';
-
-import * as styles from './MemberAssignmentPanel.css';
-import { User } from '@web/types/organization';
+import type { UserResult } from '@web/types/organization';
 import MemberListItem from './MemberListItem';
+import * as styles from './MemberAssignmentPanel.css';
 
 interface MemberPanelProps {
   title: string;
   count: number;
-  items: User[];
-  selected: Set<string>;
+  items: UserResult[];
+  selected: Set<number>;
   allSelected: boolean;
   onToggleAll: () => void;
   onAction: () => void;
   actionLabel: string;
   actionIcon: ReactElement;
-  onToggleItem: (id: string) => void;
+  onToggleItem: (id: number) => void;
   search: string;
 }
 
@@ -50,7 +50,6 @@ export default function MemberPanel({
         <div style={{ width: '2rem', height: '2rem' }}>
           <CheckBox size={2} isChecked={allSelected} onChange={onToggleAll} />
         </div>
-
         <Button
           disabled={selected.size === 0}
           onClick={onAction}
@@ -65,10 +64,10 @@ export default function MemberPanel({
       <div className={styles.list}>
         {items.map((u) => (
           <MemberListItem
-            key={u.id}
+            key={u.userId}
             user={u}
-            isSelected={selected.has(u.id)}
-            onToggle={() => onToggleItem(u.id)}
+            isSelected={selected.has(u.userId)}
+            onToggle={() => onToggleItem(u.userId)}
             search={search}
           />
         ))}

--- a/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberPanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/MemberAssignmentPanel/MemberPanel.tsx
@@ -1,4 +1,3 @@
-// src/app/(main)/settings/_components/MemberPanel.tsx
 import React, { ReactElement } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { Text } from '@repo/ui/Text';

--- a/apps/web/src/app/(main)/organization/_components/OrgList/OrgList.tsx
+++ b/apps/web/src/app/(main)/organization/_components/OrgList/OrgList.tsx
@@ -4,15 +4,16 @@ import React from 'react';
 import * as styles from './OrgList.css';
 import { OrgListHeader } from './OrgListHeader';
 import OrgListItem from '../OrgListItem/OrgListItem';
-import { Member, Role } from '@web/types/organization';
+import { Member, OrgRole, Role } from '@web/types/organization';
 
 interface Props {
   data: Member[];
   selectedIds: string[];
   onToggleAll: (checked: boolean) => void;
   onToggleOne: (id: string, checked: boolean) => void;
-  availableRoles: Role[];
-  onAddRole: (memberId: string, role: Role) => void;
+  availableRoles: OrgRole[];
+  // 💥 onAddRole 에도 OrgRole 타입을 맞춰 줍니다
+  onAddRole: (memberId: string, role: OrgRole) => void;
   search: string;
 }
 

--- a/apps/web/src/app/(main)/organization/_components/OrgListItem/OrgListItem.tsx
+++ b/apps/web/src/app/(main)/organization/_components/OrgListItem/OrgListItem.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import * as styles from './OrgListItem.css';
-import { Member } from '@web/types/organization';
+import { Member, OrgRole } from '@web/types/organization';
 import { CheckBox } from '@repo/ui/CheckBox';
 import { Tag } from '@repo/ui/Tag';
 import { RolesDropdown } from '@repo/ui/DropDown';
@@ -15,8 +15,8 @@ interface Props {
   member: Member;
   isSelected: boolean;
   onToggle: (checked: boolean) => void;
-  availableRoles: Member['roles'];
-  onAddRole: (role: Member['roles'][number]) => void;
+  availableRoles: OrgRole[];
+  onAddRole: (role: OrgRole) => void;
   search: string;
 }
 

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RoleItem.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RoleItem.tsx
@@ -51,7 +51,7 @@ export function RoleItem({
           )
         )}
       </Text>
-      <Text variant="sm_caption_regular" color="grayscale50">
+      <Text variant="sm_caption_regular" color="grayscale40">
         {count}
       </Text>
     </Flex>

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RoleItem.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RoleItem.tsx
@@ -12,6 +12,7 @@ interface RoleItemProps {
   isSelected: boolean;
   onClick: () => void;
   onDoubleClick: () => void;
+  count?: number;
 }
 
 export function RoleItem({
@@ -21,6 +22,7 @@ export function RoleItem({
   isSelected,
   onClick,
   onDoubleClick,
+  count,
 }: RoleItemProps) {
   const parts = search ? label.split(new RegExp(`(${search})`, 'gi')) : [label];
 
@@ -48,6 +50,9 @@ export function RoleItem({
             <React.Fragment key={idx}>{part}</React.Fragment>
           )
         )}
+      </Text>
+      <Text variant="sm_caption_regular" color="grayscale50">
+        {count}
       </Text>
     </Flex>
   );

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
@@ -7,7 +7,7 @@ import { SearchInput } from '@repo/ui/SearchInput';
 import { Button } from '@repo/ui/Button';
 import { IcRoleBtn } from '@repo/ui/icons/mono';
 import * as styles from './RolePalettePanel.css';
-import type { RoleSelect } from '@web/types/organization';
+import type { RoleSelect, RoleSelectWithCount } from '@web/types/organization';
 import type { PaletteColor } from '@repo/utils';
 import { RoleEditor } from './RoleEditor';
 import { RoleItem } from './RoleItem';
@@ -26,7 +26,7 @@ const COLOR_OPTIONS: PaletteColor[] = [
 ];
 
 interface Props {
-  roles: RoleSelect[];
+  roles: RoleSelectWithCount[];
   onAddRole: (r: RoleSelect) => void;
   onUpdateRole: (i: number, label: string, color: PaletteColor) => void;
 }
@@ -137,6 +137,7 @@ export default function RolePalettePanel({
                 label={r.label}
                 color={r.color as PaletteColor}
                 search={search}
+                count={r.count}
                 isSelected={isSelected}
                 onClick={() => {
                   setSelectedIdx(isSelected ? null : i);

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
@@ -1,5 +1,5 @@
+// src/app/(main)/settings/_components/RolePalettePanel.tsx
 'use client';
-
 import React, { useState, ChangeEvent, KeyboardEvent } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { Text } from '@repo/ui/Text';
@@ -7,7 +7,7 @@ import { SearchInput } from '@repo/ui/SearchInput';
 import { Button } from '@repo/ui/Button';
 import { IcRoleBtn } from '@repo/ui/icons/mono';
 import * as styles from './RolePalettePanel.css';
-import type { RoleSelect, RoleSelectWithCount } from '@web/types/organization';
+import type { RoleSelectWithCount } from '@web/types/organization';
 import type { PaletteColor } from '@repo/utils';
 import { RoleEditor } from './RoleEditor';
 import { RoleItem } from './RoleItem';
@@ -28,30 +28,28 @@ const COLOR_OPTIONS: PaletteColor[] = [
 interface Props {
   roles: RoleSelectWithCount[];
   search: string;
-  onAddRole: (r: RoleSelect) => void;
-  onSearchChange?: (value: string) => void;
+  selectedIdx: number | null;
+  onSelectRole: (i: number) => void;
+  onSearchChange?: (v: string) => void;
+  onAddRole: (r: { label: string; color: PaletteColor }) => void;
   onUpdateRole: (i: number, label: string, color: PaletteColor) => void;
 }
-
 export default function RolePalettePanel({
   roles,
   search,
+  selectedIdx,
+  onSelectRole,
+  onSearchChange,
   onAddRole,
   onUpdateRole,
-  onSearchChange,
 }: Props) {
   const [isAdding, setIsAdding] = useState(false);
   const [newLabel, setNewLabel] = useState('');
-  const [newColor, setNewColor] = useState<PaletteColor>(COLOR_OPTIONS[0]!);
-  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [newColor, setNewColor] = useState(COLOR_OPTIONS[0]!);
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [editLabel, setEditLabel] = useState('');
-  const [editColor, setEditColor] = useState<PaletteColor>(COLOR_OPTIONS[0]!);
+  const [editColor, setEditColor] = useState(COLOR_OPTIONS[0]!);
   const [editOpen, setEditOpen] = useState(false);
-
-  /*const filtered = roles.filter((r) =>
-    r.label.toLowerCase().includes(search.toLowerCase())
-  );*/
 
   const handleAddKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && newLabel.trim()) {
@@ -60,65 +58,45 @@ export default function RolePalettePanel({
       setNewLabel('');
     }
   };
-
   const handleEditKey = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && editingIdx !== null) {
+    if (e.key === 'Enter' && editingIdx != null) {
       onUpdateRole(editingIdx, editLabel.trim(), editColor);
       setEditingIdx(null);
       setEditOpen(false);
-      if (selectedIdx !== editingIdx) setSelectedIdx(null);
     }
   };
 
   return (
     <div className={styles.root}>
       <Flex align="center" gap="0.8rem">
-        <Text variant="md1_text_semibold" color="grayscale90">
-          역할
-        </Text>
-        <Text variant="md1_text_medium" color="grayscale30">
-          {roles.length}
-        </Text>
+        <Text variant="md1_text_semibold">역할</Text>
+        <Text variant="md1_text_medium">{roles.length}</Text>
       </Flex>
-
       <div style={{ height: '4rem' }}>
         <SearchInput
           value={search}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            onSearchChange?.(e.target.value)
-          }
+          onChange={(e) => onSearchChange?.(e.target.value)}
           width="100%"
         />
       </div>
-
-      <Flex
-        width="100%"
-        direction="column"
-        gap="1.2rem"
-        marginTop="0.8rem"
-        className={styles.listContainer}
-      >
+      <Flex direction="column" gap="1.2rem" marginTop="0.8rem">
         <Button
-          variant="basic"
-          size="32"
           leftIcon={<IcRoleBtn />}
           onClick={() => {
             setIsAdding(true);
-            setNewLabel('');
-            setNewColor(COLOR_OPTIONS[0]!);
             setEditingIdx(null);
           }}
           width="100%"
+          size="32"
+          variant="basic"
         >
           추가
         </Button>
-
         <div className={styles.list}>
           {roles.map((r, i) => {
-            const isSelected = selectedIdx === i;
-            const isEditing = editingIdx === i;
-
-            if (isEditing) {
+            const isSel = selectedIdx === i;
+            const isEd = editingIdx === i;
+            if (isEd) {
               return (
                 <RoleEditor
                   key={`edit-${i}`}
@@ -127,44 +105,39 @@ export default function RolePalettePanel({
                   isOpen={editOpen}
                   options={COLOR_OPTIONS}
                   onLabelChange={(e) => setEditLabel(e.target.value)}
-                  onColorChange={setEditColor}
+                  onColorChange={(c) => setEditColor(c)}
                   onKeyDown={handleEditKey}
                   onTogglePalette={() => setEditOpen((o) => !o)}
                 />
               );
             }
-
             return (
               <RoleItem
                 key={i}
                 label={r.label}
-                color={r.color as PaletteColor}
-                search={search}
+                color={r.color}
                 count={r.count}
-                isSelected={isSelected}
-                onClick={() => {
-                  setSelectedIdx(isSelected ? null : i);
-                  setEditingIdx(null);
-                }}
+                search={search}
+                isSelected={isSel}
+                onClick={() => onSelectRole(i)}
                 onDoubleClick={() => {
                   setEditingIdx(i);
                   setEditLabel(r.label);
-                  setEditColor(r.color as PaletteColor);
+                  setEditColor(r.color);
                   setEditOpen(false);
                 }}
               />
             );
           })}
-
           {isAdding && (
             <RoleEditor
               key="add"
               label={newLabel}
               color={newColor}
-              isOpen={true}
+              isOpen
               options={COLOR_OPTIONS}
               onLabelChange={(e) => setNewLabel(e.target.value)}
-              onColorChange={setNewColor}
+              onColorChange={(c) => setNewColor(c)}
               onKeyDown={handleAddKey}
               onTogglePalette={() => setEditOpen((o) => !o)}
             />

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
@@ -1,4 +1,3 @@
-// src/app/(main)/settings/_components/RolePalettePanel.tsx
 'use client';
 import React, { useState, ChangeEvent, KeyboardEvent } from 'react';
 import { Flex } from '@repo/ui/Flex';

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
@@ -27,16 +27,19 @@ const COLOR_OPTIONS: PaletteColor[] = [
 
 interface Props {
   roles: RoleSelectWithCount[];
+  search: string;
   onAddRole: (r: RoleSelect) => void;
+  onSearchChange?: (value: string) => void;
   onUpdateRole: (i: number, label: string, color: PaletteColor) => void;
 }
 
 export default function RolePalettePanel({
   roles,
+  search,
   onAddRole,
   onUpdateRole,
+  onSearchChange,
 }: Props) {
-  const [search, setSearch] = useState('');
   const [isAdding, setIsAdding] = useState(false);
   const [newLabel, setNewLabel] = useState('');
   const [newColor, setNewColor] = useState<PaletteColor>(COLOR_OPTIONS[0]!);
@@ -46,9 +49,9 @@ export default function RolePalettePanel({
   const [editColor, setEditColor] = useState<PaletteColor>(COLOR_OPTIONS[0]!);
   const [editOpen, setEditOpen] = useState(false);
 
-  const filtered = roles.filter((r) =>
+  /*const filtered = roles.filter((r) =>
     r.label.toLowerCase().includes(search.toLowerCase())
-  );
+  );*/
 
   const handleAddKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && newLabel.trim()) {
@@ -82,7 +85,7 @@ export default function RolePalettePanel({
         <SearchInput
           value={search}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setSearch(e.target.value)
+            onSearchChange?.(e.target.value)
           }
           width="100%"
         />
@@ -111,7 +114,7 @@ export default function RolePalettePanel({
         </Button>
 
         <div className={styles.list}>
-          {filtered.map((r, i) => {
+          {roles.map((r, i) => {
             const isSelected = selectedIdx === i;
             const isEditing = editingIdx === i;
 

--- a/apps/web/src/app/(main)/organization/settings/Settings.tsx
+++ b/apps/web/src/app/(main)/organization/settings/Settings.tsx
@@ -1,4 +1,3 @@
-// ─── Settings.tsx ──────────────────────────────────────────────────────────
 'use client';
 import { useState, useEffect, useMemo } from 'react';
 import { Flex } from '@repo/ui/Flex';
@@ -23,7 +22,7 @@ export default function Settings({ organizationId }: Props) {
   const [roleSearch, setRoleSearch] = useState('');
   const [selectedRoleIdx, setSelectedRoleIdx] = useState<number | null>(null);
 
-  // 1) 역할 목록
+  // 역할 목록
   const { data: rolesData } = useSuspenseQuery(
     getOrganizationRolesQueryOptions({ organizationId })
   );
@@ -42,13 +41,13 @@ export default function Settings({ organizationId }: Props) {
   const selectedRoleId =
     selectedRoleIdx != null ? filteredRoles[selectedRoleIdx]!.id : 0;
 
-  // 2) 서버에서 users
+  // 서버에서 users
   const { data: users } = useOrganizationUsersQuery(
     organizationId,
     selectedRoleId
   );
 
-  // 3) local state: roleId 가 바뀔 때만 초기화
+  // roleId 가 바뀔 때만 초기화
   const [localUsers, setLocalUsers] = useState<UserResult[]>([]);
   useEffect(() => {
     if (selectedRoleId === 0) {
@@ -58,11 +57,10 @@ export default function Settings({ organizationId }: Props) {
     }
   }, [selectedRoleId, users]);
 
-  // 4) 분리
   const addedMembers = localUsers.filter((u) => u.isAssigned);
   const availableMembers = localUsers.filter((u) => !u.isAssigned);
 
-  // 5) 즉시 UI 반영용 토글
+  //  즉시 UI 반영
   const handleAdd = (u: UserResult) =>
     setLocalUsers((ls) =>
       ls.map((x) => (x.userId === u.userId ? { ...x, isAssigned: true } : x))
@@ -72,16 +70,16 @@ export default function Settings({ organizationId }: Props) {
       ls.map((x) => (x.userId === u.userId ? { ...x, isAssigned: false } : x))
     );
 
-  // 6) 역할 뮤테이션
+  // 역할
   const { mutate: addRole } = useAddOrganizationRoleMutation(organizationId);
   const { mutate: updateRole } =
     useUpdateOrganizationRoleMutation(organizationId);
 
-  // 7) 할당/제외 뮤테이션
+  //  할당/제외
   const { mutate: assignUsers } =
     useAssignOrganizationUsersMutation(organizationId);
 
-  // 8) 저장: 비어 있으면 [0] 전송
+  // 저장, 비어 있으면 [0] 전송
   const handleSave = () => {
     if (!selectedRoleId) return;
     const userIds =

--- a/apps/web/src/app/(main)/organization/settings/Settings.tsx
+++ b/apps/web/src/app/(main)/organization/settings/Settings.tsx
@@ -1,102 +1,114 @@
-// src/app/(main)/settings/Settings.tsx
+// ─── Settings.tsx ──────────────────────────────────────────────────────────
 'use client';
-
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import SettingsHeader from '../_components/SettingsHeader/SettingsHeader';
 import RolePalettePanel from '../_components/RolePalettePanel/RolePalettePanel';
 import MemberAssignmentPanel from '../_components/MemberAssignmentPanel/MemberAssignmentPanel';
+import { nameToHex } from '@web/utils/color';
+import type { RoleSelectWithCount, UserResult } from '@web/types/organization';
+import type { PaletteColor } from '@repo/utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
+import { useOrganizationUsersQuery } from '@web/store/query/useOrganizationUsersQuery';
 import { useAddOrganizationRoleMutation } from '@web/store/mutation/useAddOrganizationRoleMutation';
 import { useUpdateOrganizationRoleMutation } from '@web/store/mutation/useUpdateOrganizationRoleMutation';
-import { nameToHex } from '@web/utils/color';
-import { INITIAL_SELECTED } from '@web/constants/organization';
-import type { RoleSelectWithCount, User } from '@web/types/organization';
-import type { PaletteColor } from '@repo/utils';
+import { useAssignOrganizationUsersMutation } from '@web/store/mutation/useAssignOrganizationUsersMutation';
 
 interface Props {
   organizationId: number;
 }
 
 export default function Settings({ organizationId }: Props) {
-  const [searchInput, setSearchInput] = useState('');
+  const [roleSearch, setRoleSearch] = useState('');
+  const [selectedRoleIdx, setSelectedRoleIdx] = useState<number | null>(null);
 
-  // 1) 전체 역할 목록을 한 번만 가져옴
-  const { data } = useSuspenseQuery(
+  // 1) 역할 목록
+  const { data: rolesData } = useSuspenseQuery(
     getOrganizationRolesQueryOptions({ organizationId })
   );
-
-  // 2) 메모리에서 검색어 기준으로 필터링
   const filteredRoles = useMemo(
     () =>
-      data.roles.filter((r) =>
-        r.roleName.toLowerCase().includes(searchInput.toLowerCase())
+      rolesData.roles.filter((r) =>
+        r.roleName.toLowerCase().includes(roleSearch.toLowerCase())
       ),
-    [data.roles, searchInput]
+    [rolesData.roles, roleSearch]
   );
-
-  // 3) RolePalettePanel 용으로 매핑
   const roleSelect: RoleSelectWithCount[] = filteredRoles.map((r) => ({
     label: r.roleName,
     color: nameToHex[r.color] as PaletteColor,
     count: r.assignedUserCount,
   }));
+  const selectedRoleId =
+    selectedRoleIdx != null ? filteredRoles[selectedRoleIdx]!.id : 0;
 
-  // 뮤테이션 훅
+  // 2) 서버에서 users
+  const { data: users } = useOrganizationUsersQuery(
+    organizationId,
+    selectedRoleId
+  );
+
+  // 3) local state: roleId 가 바뀔 때만 초기화
+  const [localUsers, setLocalUsers] = useState<UserResult[]>([]);
+  useEffect(() => {
+    if (selectedRoleId === 0) {
+      setLocalUsers([]);
+    } else if (users) {
+      setLocalUsers(users);
+    }
+  }, [selectedRoleId, users]);
+
+  // 4) 분리
+  const addedMembers = localUsers.filter((u) => u.isAssigned);
+  const availableMembers = localUsers.filter((u) => !u.isAssigned);
+
+  // 5) 즉시 UI 반영용 토글
+  const handleAdd = (u: UserResult) =>
+    setLocalUsers((ls) =>
+      ls.map((x) => (x.userId === u.userId ? { ...x, isAssigned: true } : x))
+    );
+  const handleRemove = (u: UserResult) =>
+    setLocalUsers((ls) =>
+      ls.map((x) => (x.userId === u.userId ? { ...x, isAssigned: false } : x))
+    );
+
+  // 6) 역할 뮤테이션
   const { mutate: addRole } = useAddOrganizationRoleMutation(organizationId);
   const { mutate: updateRole } =
     useUpdateOrganizationRoleMutation(organizationId);
 
-  // 멤버 할당 상태
-  const [addedMembers, setAddedMembers] = useState<User[]>([]);
-  const [availableMembers, setAvailableMembers] =
-    useState<User[]>(INITIAL_SELECTED);
+  // 7) 할당/제외 뮤테이션
+  const { mutate: assignUsers } =
+    useAssignOrganizationUsersMutation(organizationId);
 
-  const handleAddRole = (newRole: { label: string; color: PaletteColor }) => {
-    addRole({ label: newRole.label, color: newRole.color });
-  };
-
-  const handleUpdateRole = (
-    idx: number,
-    label: string,
-    color: PaletteColor
-  ) => {
-    const role = filteredRoles[idx];
-    updateRole({ roleId: role!.id, label, color });
-  };
-
-  const handleAddMember = (u: User) => {
-    setAvailableMembers((av) => av.filter((x) => x.id !== u.id));
-    setAddedMembers((ad) => [...ad, u]);
-  };
-  const handleRemoveMember = (u: User) => {
-    setAddedMembers((ad) => ad.filter((x) => x.id !== u.id));
-    setAvailableMembers((av) => [...av, u]);
-  };
-
+  // 8) 저장: 비어 있으면 [0] 전송
   const handleSave = () => {
-    // 저장 API 호출
+    if (!selectedRoleId) return;
+    const userIds =
+      addedMembers.length > 0 ? addedMembers.map((u) => u.userId) : [0];
+    assignUsers({ roleId: selectedRoleId, userIds });
   };
 
   return (
     <Flex direction="column">
       <SettingsHeader onSave={handleSave} />
-
       <Flex align="center" gap="1.9rem" width="100%" marginTop="1.8rem">
         <RolePalettePanel
           roles={roleSelect}
-          search={searchInput}
-          onSearchChange={setSearchInput}
-          onAddRole={handleAddRole}
-          onUpdateRole={handleUpdateRole}
+          search={roleSearch}
+          selectedIdx={selectedRoleIdx}
+          onSearchChange={setRoleSearch}
+          onSelectRole={setSelectedRoleIdx}
+          onAddRole={addRole}
+          onUpdateRole={(i, label, color) =>
+            updateRole({ roleId: filteredRoles[i]!.id, label, color })
+          }
         />
-
         <MemberAssignmentPanel
           addedMembers={addedMembers}
           availableMembers={availableMembers}
-          onAdd={handleAddMember}
-          onRemove={handleRemoveMember}
+          onAdd={handleAdd}
+          onRemove={handleRemove}
         />
       </Flex>
     </Flex>

--- a/apps/web/src/app/(main)/organization/settings/Settings.tsx
+++ b/apps/web/src/app/(main)/organization/settings/Settings.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Flex } from '@repo/ui/Flex';
+import SettingsHeader from '../_components/SettingsHeader/SettingsHeader';
+import RolePalettePanel from '../_components/RolePalettePanel/RolePalettePanel';
+import {
+  Role,
+  RoleSelect,
+  RoleSelectWithCount,
+  User,
+} from '@web/types/organization';
+import { useState } from 'react';
+import { ALL_ROLES, INITIAL_SELECTED } from '@web/constants/organization';
+import MemberAssignmentPanel from '../_components/MemberAssignmentPanel/MemberAssignmentPanel';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
+import { useAddOrganizationRoleMutation } from '@web/store/mutation/useAddOrganizationRoleMutation';
+import { PaletteColor } from '@repo/utils';
+import { hexToName, nameToHex } from '@web/utils/color';
+
+interface Props {
+  organizationId: number;
+}
+
+export default function Settings({ organizationId }: Props) {
+  const { data } = useSuspenseQuery(
+    getOrganizationRolesQueryOptions({ organizationId })
+  );
+
+  const { mutate: addRole } = useAddOrganizationRoleMutation(organizationId);
+  // 역할 목록
+  //const [roles, setRoles] = useState<RoleSelect[]>(ALL_ROLES);
+
+  // “추가된 멤버” & “추가하지 않은 멤버”
+  const [added, setAdded] = useState<User[]>([]);
+  const [available, setAvailable] = useState<User[]>(INITIAL_SELECTED);
+
+  // Role 팔레트 → 역할 추가
+  const handleAddRole = (newRole: { label: string; color: PaletteColor }) => {
+    addRole({
+      label: newRole.label,
+      color: newRole.color,
+    });
+  };
+
+  // Role 이름 수정
+  /*const handleUpdateRole = (
+    idx: number,
+    label: string,
+    color: RoleSelect['color']
+  ) => {
+    setRoles((prev) => {
+      const copy = [...prev];
+      copy[idx] = { ...copy[idx], label, color };
+      return copy;
+    });
+  };*/
+  const handleUpdateRole = (idx: number, label: string, color: string) => {
+    // TODO: 역할 수정 API 필요 시 연동
+    console.log('update role', idx, label, color);
+  };
+
+  const handleAddMember = (u: User) => {
+    setAvailable((av) => av.filter((x) => x.id !== u.id));
+    setAdded((ad) => [...ad, u]);
+  };
+  const handleRemoveMember = (u: User) => {
+    setAdded((ad) => ad.filter((x) => x.id !== u.id));
+    setAvailable((av) => [...av, u]);
+  };
+
+  const handleSave = () => {
+    // 저장 API
+  };
+
+  const roleSelect: RoleSelectWithCount[] = data.roles.map((r) => ({
+    label: r.roleName,
+    color: nameToHex[r.color] as PaletteColor,
+    count: r.assignedUserCount,
+  }));
+
+  return (
+    <Flex direction="column">
+      <SettingsHeader onSave={handleSave} />
+      <Flex align="center" gap="1.9rem" width="100%" marginTop="1.8rem">
+        <RolePalettePanel
+          roles={roleSelect}
+          onAddRole={handleAddRole}
+          onUpdateRole={handleUpdateRole}
+        />
+
+        <MemberAssignmentPanel
+          addedMembers={added}
+          availableMembers={available}
+          onAdd={handleAddMember}
+          onRemove={handleRemoveMember}
+        />
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/web/src/app/(main)/organization/settings/Settings.tsx
+++ b/apps/web/src/app/(main)/organization/settings/Settings.tsx
@@ -1,97 +1,100 @@
+// src/app/(main)/settings/Settings.tsx
 'use client';
 
+import { useState, useMemo } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import SettingsHeader from '../_components/SettingsHeader/SettingsHeader';
 import RolePalettePanel from '../_components/RolePalettePanel/RolePalettePanel';
-import {
-  Role,
-  RoleSelect,
-  RoleSelectWithCount,
-  User,
-} from '@web/types/organization';
-import { useState } from 'react';
-import { ALL_ROLES, INITIAL_SELECTED } from '@web/constants/organization';
 import MemberAssignmentPanel from '../_components/MemberAssignmentPanel/MemberAssignmentPanel';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
 import { useAddOrganizationRoleMutation } from '@web/store/mutation/useAddOrganizationRoleMutation';
-import { PaletteColor } from '@repo/utils';
-import { hexToName, nameToHex } from '@web/utils/color';
+import { useUpdateOrganizationRoleMutation } from '@web/store/mutation/useUpdateOrganizationRoleMutation';
+import { nameToHex } from '@web/utils/color';
+import { INITIAL_SELECTED } from '@web/constants/organization';
+import type { RoleSelectWithCount, User } from '@web/types/organization';
+import type { PaletteColor } from '@repo/utils';
 
 interface Props {
   organizationId: number;
 }
 
 export default function Settings({ organizationId }: Props) {
+  const [searchInput, setSearchInput] = useState('');
+
+  // 1) 전체 역할 목록을 한 번만 가져옴
   const { data } = useSuspenseQuery(
     getOrganizationRolesQueryOptions({ organizationId })
   );
 
-  const { mutate: addRole } = useAddOrganizationRoleMutation(organizationId);
-  // 역할 목록
-  //const [roles, setRoles] = useState<RoleSelect[]>(ALL_ROLES);
+  // 2) 메모리에서 검색어 기준으로 필터링
+  const filteredRoles = useMemo(
+    () =>
+      data.roles.filter((r) =>
+        r.roleName.toLowerCase().includes(searchInput.toLowerCase())
+      ),
+    [data.roles, searchInput]
+  );
 
-  // “추가된 멤버” & “추가하지 않은 멤버”
-  const [added, setAdded] = useState<User[]>([]);
-  const [available, setAvailable] = useState<User[]>(INITIAL_SELECTED);
-
-  // Role 팔레트 → 역할 추가
-  const handleAddRole = (newRole: { label: string; color: PaletteColor }) => {
-    addRole({
-      label: newRole.label,
-      color: newRole.color,
-    });
-  };
-
-  // Role 이름 수정
-  /*const handleUpdateRole = (
-    idx: number,
-    label: string,
-    color: RoleSelect['color']
-  ) => {
-    setRoles((prev) => {
-      const copy = [...prev];
-      copy[idx] = { ...copy[idx], label, color };
-      return copy;
-    });
-  };*/
-  const handleUpdateRole = (idx: number, label: string, color: string) => {
-    // TODO: 역할 수정 API 필요 시 연동
-    console.log('update role', idx, label, color);
-  };
-
-  const handleAddMember = (u: User) => {
-    setAvailable((av) => av.filter((x) => x.id !== u.id));
-    setAdded((ad) => [...ad, u]);
-  };
-  const handleRemoveMember = (u: User) => {
-    setAdded((ad) => ad.filter((x) => x.id !== u.id));
-    setAvailable((av) => [...av, u]);
-  };
-
-  const handleSave = () => {
-    // 저장 API
-  };
-
-  const roleSelect: RoleSelectWithCount[] = data.roles.map((r) => ({
+  // 3) RolePalettePanel 용으로 매핑
+  const roleSelect: RoleSelectWithCount[] = filteredRoles.map((r) => ({
     label: r.roleName,
     color: nameToHex[r.color] as PaletteColor,
     count: r.assignedUserCount,
   }));
 
+  // 뮤테이션 훅
+  const { mutate: addRole } = useAddOrganizationRoleMutation(organizationId);
+  const { mutate: updateRole } =
+    useUpdateOrganizationRoleMutation(organizationId);
+
+  // 멤버 할당 상태
+  const [addedMembers, setAddedMembers] = useState<User[]>([]);
+  const [availableMembers, setAvailableMembers] =
+    useState<User[]>(INITIAL_SELECTED);
+
+  const handleAddRole = (newRole: { label: string; color: PaletteColor }) => {
+    addRole({ label: newRole.label, color: newRole.color });
+  };
+
+  const handleUpdateRole = (
+    idx: number,
+    label: string,
+    color: PaletteColor
+  ) => {
+    const role = filteredRoles[idx];
+    updateRole({ roleId: role!.id, label, color });
+  };
+
+  const handleAddMember = (u: User) => {
+    setAvailableMembers((av) => av.filter((x) => x.id !== u.id));
+    setAddedMembers((ad) => [...ad, u]);
+  };
+  const handleRemoveMember = (u: User) => {
+    setAddedMembers((ad) => ad.filter((x) => x.id !== u.id));
+    setAvailableMembers((av) => [...av, u]);
+  };
+
+  const handleSave = () => {
+    // 저장 API 호출
+  };
+
   return (
     <Flex direction="column">
       <SettingsHeader onSave={handleSave} />
+
       <Flex align="center" gap="1.9rem" width="100%" marginTop="1.8rem">
         <RolePalettePanel
           roles={roleSelect}
+          search={searchInput}
+          onSearchChange={setSearchInput}
           onAddRole={handleAddRole}
           onUpdateRole={handleUpdateRole}
         />
 
         <MemberAssignmentPanel
-          addedMembers={added}
-          availableMembers={available}
+          addedMembers={addedMembers}
+          availableMembers={availableMembers}
           onAdd={handleAddMember}
           onRemove={handleRemoveMember}
         />

--- a/apps/web/src/app/(main)/organization/settings/page.tsx
+++ b/apps/web/src/app/(main)/organization/settings/page.tsx
@@ -1,67 +1,20 @@
-'use client';
+import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
+import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
+import Settings from './Settings';
+import { getServerSideTokens } from '@web/api/serverSideTokens';
 
-import { Flex } from '@repo/ui/Flex';
-import SettingsHeader from '../_components/SettingsHeader/SettingsHeader';
-import RolePalettePanel from '../_components/RolePalettePanel/RolePalettePanel';
-import { Role, RoleSelect, User } from '@web/types/organization';
-import { useState } from 'react';
-import { ALL_ROLES, INITIAL_SELECTED } from '@web/constants/organization';
-import MemberAssignmentPanel from '../_components/MemberAssignmentPanel/MemberAssignmentPanel';
+export default async function Page() {
+  const tokens = await getServerSideTokens();
+  // 추후에 전역상태관리 사용해서 변환하기!!
+  const organizationId = 1;
 
-export default function SettingsPage() {
-  // 역할 목록
-  const [roles, setRoles] = useState<RoleSelect[]>(ALL_ROLES);
-
-  // “추가된 멤버” & “추가하지 않은 멤버”
-  const [added, setAdded] = useState<User[]>([]);
-  const [available, setAvailable] = useState<User[]>(INITIAL_SELECTED);
-
-  // Role 팔레트 → 역할 추가
-  const handleAddRole = (newRole: RoleSelect) => setRoles([...roles, newRole]);
-
-  // Role 이름 수정
-  const handleUpdateRole = (
-    idx: number,
-    label: string,
-    color: RoleSelect['color']
-  ) => {
-    setRoles((prev) => {
-      const copy = [...prev];
-      copy[idx] = { ...copy[idx], label, color };
-      return copy;
-    });
-  };
-
-  const handleAddMember = (u: User) => {
-    setAvailable((av) => av.filter((x) => x.id !== u.id));
-    setAdded((ad) => [...ad, u]);
-  };
-  const handleRemoveMember = (u: User) => {
-    setAdded((ad) => ad.filter((x) => x.id !== u.id));
-    setAvailable((av) => [...av, u]);
-  };
-
-  const handleSave = () => {
-    // 저장 API
-  };
+  const fetchOptions = [
+    getOrganizationRolesQueryOptions({ organizationId, tokens }),
+  ];
 
   return (
-    <Flex direction="column">
-      <SettingsHeader onSave={handleSave} />
-      <Flex align="center" gap="1.9rem" width="100%" marginTop="1.8rem">
-        <RolePalettePanel
-          roles={roles}
-          onAddRole={handleAddRole}
-          onUpdateRole={handleUpdateRole}
-        />
-
-        <MemberAssignmentPanel
-          addedMembers={added}
-          availableMembers={available}
-          onAdd={handleAddMember}
-          onRemove={handleRemoveMember}
-        />
-      </Flex>
-    </Flex>
+    <ServerFetchBoundary fetchOptions={fetchOptions}>
+      <Settings organizationId={organizationId} />
+    </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/(main)/organization/settings/page.tsx
+++ b/apps/web/src/app/(main)/organization/settings/page.tsx
@@ -6,7 +6,7 @@ import { getServerSideTokens } from '@web/api/serverSideTokens';
 export default async function Page() {
   const tokens = await getServerSideTokens();
   // 추후에 전역상태관리 사용해서 변환하기!!
-  const organizationId = 1;
+  const organizationId = 3;
 
   const fetchOptions = [
     getOrganizationRolesQueryOptions({ organizationId, tokens }),

--- a/apps/web/src/store/constants/index.ts
+++ b/apps/web/src/store/constants/index.ts
@@ -1,0 +1,1 @@
+export { queryKeys } from './queryKeys';

--- a/apps/web/src/store/constants/queryKeys.ts
+++ b/apps/web/src/store/constants/queryKeys.ts
@@ -1,1 +1,16 @@
-// 쿼리 키 관련 파일들 constants 에!!
+export const queryKeys = {
+  organization: {
+    roles: {
+      list: (organizationId: number, keyword?: string) =>
+        keyword
+          ? ([
+              'organization',
+              organizationId,
+              'roles',
+              'search',
+              keyword,
+            ] as const)
+          : (['organization', organizationId, 'roles'] as const),
+    },
+  },
+} as const;

--- a/apps/web/src/store/constants/queryKeys.ts
+++ b/apps/web/src/store/constants/queryKeys.ts
@@ -32,5 +32,17 @@ export const queryKeys = {
               roleId,
             ] as const),
     },
+    members: {
+      // 전체 조직 사용자(멤버) 목록 조회 (페이징)
+      list: (organizationId: number, page: number, size: number) =>
+        [
+          'organization',
+          organizationId,
+          'members',
+          'list',
+          page,
+          size,
+        ] as const,
+    },
   },
 } as const;

--- a/apps/web/src/store/constants/queryKeys.ts
+++ b/apps/web/src/store/constants/queryKeys.ts
@@ -1,4 +1,3 @@
-// src/store/organization/constants.ts
 export const queryKeys = {
   organization: {
     roles: {
@@ -33,7 +32,6 @@ export const queryKeys = {
             ] as const),
     },
     members: {
-      // 전체 조직 사용자(멤버) 목록 조회 (페이징)
       list: (organizationId: number, page: number, size: number) =>
         [
           'organization',

--- a/apps/web/src/store/constants/queryKeys.ts
+++ b/apps/web/src/store/constants/queryKeys.ts
@@ -1,3 +1,4 @@
+// src/store/organization/constants.ts
 export const queryKeys = {
   organization: {
     roles: {
@@ -11,6 +12,25 @@ export const queryKeys = {
               keyword,
             ] as const)
           : (['organization', organizationId, 'roles'] as const),
+    },
+    users: {
+      search: (organizationId: number, roleId: number, keyword?: string) =>
+        keyword
+          ? ([
+              'organization',
+              organizationId,
+              'users',
+              'search',
+              roleId,
+              keyword,
+            ] as const)
+          : ([
+              'organization',
+              organizationId,
+              'users',
+              'search',
+              roleId,
+            ] as const),
     },
   },
 } as const;

--- a/apps/web/src/store/mutation/useAddOrganizationRoleMutation.ts
+++ b/apps/web/src/store/mutation/useAddOrganizationRoleMutation.ts
@@ -13,8 +13,6 @@ type Variables = { label: string; color: PaletteColor };
 
 /**
  * 조직 역할 생성
- * - 성공 시 반환값 void
- * - 생성 후 invalidateQueries 로 목록 갱신
  */
 export function useAddOrganizationRoleMutation(
   organizationId: number
@@ -31,7 +29,7 @@ export function useAddOrganizationRoleMutation(
         `api/v1/organizations/${organizationId}/roles`,
         payload
       );
-      console.log('역할 생성', response);
+      //console.log('역할 생성', response);
       return response.result;
     },
     onSuccess: () => {

--- a/apps/web/src/store/mutation/useAddOrganizationRoleMutation.ts
+++ b/apps/web/src/store/mutation/useAddOrganizationRoleMutation.ts
@@ -1,0 +1,43 @@
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { POST } from '@web/api/fetch';
+import { CreateRoleRequest, CreateRoleDto } from '@web/types/organization';
+import { queryKeys } from '../constants';
+import type { PaletteColor } from '@repo/utils';
+import { hexToName } from '@web/utils/color';
+
+type Variables = { label: string; color: PaletteColor };
+
+/**
+ * 조직 역할 생성
+ * - 성공 시 반환값 void
+ * - 생성 후 invalidateQueries 로 목록 갱신
+ */
+export function useAddOrganizationRoleMutation(
+  organizationId: number
+): UseMutationResult<CreateRoleDto, Error, Variables, unknown> {
+  const qc = useQueryClient();
+
+  return useMutation<CreateRoleDto, Error, Variables, unknown>({
+    mutationFn: async ({ label, color }) => {
+      const payload: CreateRoleRequest = {
+        name: label,
+        color: hexToName[color]!,
+      };
+      const response = await POST<CreateRoleDto>(
+        `api/v1/organizations/${organizationId}/roles`,
+        payload
+      );
+      console.log('역할 생성', response);
+      return response.result;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.roles.list(organizationId),
+      });
+    },
+  });
+}

--- a/apps/web/src/store/mutation/useAssignOrganizationUsersMutation.ts
+++ b/apps/web/src/store/mutation/useAssignOrganizationUsersMutation.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useAssignOrganizationUsersMutation.ts
 import {
   useMutation,
   useQueryClient,
@@ -27,29 +26,26 @@ export function useAssignOrganizationUsersMutation(
   return useMutation<AssignUsersResult[], Error, Variables, unknown>({
     mutationFn: async ({ roleId, userIds }) => {
       const payload: AssignUsersRequest = { userIds };
-      // T는 AssignUsersResult[], so PUT<AssignUsersResult[]> returns ApiResponse<AssignUsersResult[]>
+
       const res = await PUT<AssignUsersResult[]>(
         `api/v1/organizations/${organizationId}/roles/${roleId}/assign-users`,
         payload
       );
-      console.log('멤버 할당/제외 요청 완료', res);
+      //console.log('멤버 할당/제외 요청 완료', res);
       return res.result;
     },
     onSuccess: (_data, { roleId }) => {
-      console.log('멤버 할당/제외 성공:', roleId);
-
-      // 해당 역할의 운영진 목록 다시 조회
+      //console.log('멤버 할당/제외 성공:', roleId);
       qc.invalidateQueries({
         queryKey: queryKeys.organization.users.search(organizationId, roleId),
       });
 
-      // 역할별 통계(assignedUserCount) 최신화
       qc.invalidateQueries({
         queryKey: queryKeys.organization.roles.list(organizationId),
       });
     },
     onError: (error, vars) => {
-      console.error('멤버 할당/제외 실패:', vars, error);
+      //console.error('멤버 할당/제외 실패:', vars, error);
     },
   });
 }

--- a/apps/web/src/store/mutation/useAssignOrganizationUsersMutation.ts
+++ b/apps/web/src/store/mutation/useAssignOrganizationUsersMutation.ts
@@ -1,0 +1,55 @@
+// src/store/organization/useAssignOrganizationUsersMutation.ts
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { PUT } from '@web/api/fetch';
+import type {
+  AssignUsersRequest,
+  AssignUsersResult,
+} from '@web/types/organization';
+import { queryKeys } from '../constants';
+
+type Variables = {
+  roleId: number;
+  userIds: number[];
+};
+
+/**
+ * 특정 역할에 사용자 일괄 추가/제외
+ */
+export function useAssignOrganizationUsersMutation(
+  organizationId: number
+): UseMutationResult<AssignUsersResult[], Error, Variables, unknown> {
+  const qc = useQueryClient();
+
+  return useMutation<AssignUsersResult[], Error, Variables, unknown>({
+    mutationFn: async ({ roleId, userIds }) => {
+      const payload: AssignUsersRequest = { userIds };
+      // T는 AssignUsersResult[], so PUT<AssignUsersResult[]> returns ApiResponse<AssignUsersResult[]>
+      const res = await PUT<AssignUsersResult[]>(
+        `api/v1/organizations/${organizationId}/roles/${roleId}/assign-users`,
+        payload
+      );
+      console.log('멤버 할당/제외 요청 완료', res);
+      return res.result;
+    },
+    onSuccess: (_data, { roleId }) => {
+      console.log('멤버 할당/제외 성공:', roleId);
+
+      // 해당 역할의 운영진 목록 다시 조회
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.users.search(organizationId, roleId),
+      });
+
+      // 역할별 통계(assignedUserCount) 최신화
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.roles.list(organizationId),
+      });
+    },
+    onError: (error, vars) => {
+      console.error('멤버 할당/제외 실패:', vars, error);
+    },
+  });
+}

--- a/apps/web/src/store/mutation/useAssignRoleToUserMutation.ts
+++ b/apps/web/src/store/mutation/useAssignRoleToUserMutation.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useAssignRoleToUserMutation.ts
 import {
   useMutation,
   useQueryClient,
@@ -24,11 +23,10 @@ export function useAssignRoleToUserMutation(
         `api/v1/organizations/${organizationId}/assign-role`,
         payload
       );
-      console.log('역할 부여', res);
+      //console.log('역할 부여', res);
       return res.result;
     },
     onSuccess: () => {
-      // 역할 부여 후 목록 리프레시
       qc.invalidateQueries({
         queryKey: queryKeys.organization.members.list(
           organizationId,

--- a/apps/web/src/store/mutation/useAssignRoleToUserMutation.ts
+++ b/apps/web/src/store/mutation/useAssignRoleToUserMutation.ts
@@ -1,0 +1,41 @@
+// src/store/organization/useAssignRoleToUserMutation.ts
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { POST } from '@web/api/fetch';
+import type {
+  AssignRoleRequest,
+  AssignRoleResponse,
+  AssignUsersResult,
+} from '@web/types/organization';
+import { queryKeys } from '../constants';
+
+export function useAssignRoleToUserMutation(
+  organizationId: number,
+  currentPage: number,
+  pageSize: number
+): UseMutationResult<AssignUsersResult[], Error, AssignRoleRequest, unknown> {
+  const qc = useQueryClient();
+  return useMutation<AssignUsersResult[], Error, AssignRoleRequest>({
+    mutationFn: async (payload) => {
+      const res = await POST<AssignRoleResponse['result']>(
+        `api/v1/organizations/${organizationId}/assign-role`,
+        payload
+      );
+      console.log('역할 부여', res);
+      return res.result;
+    },
+    onSuccess: () => {
+      // 역할 부여 후 목록 리프레시
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.members.list(
+          organizationId,
+          currentPage,
+          pageSize
+        ),
+      });
+    },
+  });
+}

--- a/apps/web/src/store/mutation/useDeleteOrganizationUsersMutation.ts
+++ b/apps/web/src/store/mutation/useDeleteOrganizationUsersMutation.ts
@@ -1,0 +1,39 @@
+// src/store/organization/useDeleteOrganizationUsersMutation.ts
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { DELETE } from '@web/api/fetch';
+import { queryKeys } from '../constants';
+
+export function useDeleteOrganizationUsersMutation(
+  organizationId: number,
+  currentPage: number,
+  pageSize: number
+): UseMutationResult<string, Error, { userIds: number[] }, unknown> {
+  const qc = useQueryClient();
+  return useMutation<string, Error, { userIds: number[] }, unknown>({
+    mutationFn: async ({ userIds }) => {
+      // 경로 앞의 슬래시(/)를 제거합니다.
+      const res = await DELETE<string>(
+        `api/v1/organizations/${organizationId}/users`,
+        { userIds }
+      );
+      console.log('멤버 일괄 삭제', res);
+      return res.result;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.members.list(
+          organizationId,
+          currentPage,
+          pageSize
+        ),
+      });
+    },
+    onError: (error) => {
+      console.error('멤버 일괄 삭제 실패', error);
+    },
+  });
+}

--- a/apps/web/src/store/mutation/useDeleteOrganizationUsersMutation.ts
+++ b/apps/web/src/store/mutation/useDeleteOrganizationUsersMutation.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useDeleteOrganizationUsersMutation.ts
 import {
   useMutation,
   useQueryClient,
@@ -15,12 +14,11 @@ export function useDeleteOrganizationUsersMutation(
   const qc = useQueryClient();
   return useMutation<string, Error, { userIds: number[] }, unknown>({
     mutationFn: async ({ userIds }) => {
-      // 경로 앞의 슬래시(/)를 제거합니다.
       const res = await DELETE<string>(
         `api/v1/organizations/${organizationId}/users`,
         { userIds }
       );
-      console.log('멤버 일괄 삭제', res);
+      //console.log('멤버 일괄 삭제', res);
       return res.result;
     },
     onSuccess: () => {
@@ -33,7 +31,7 @@ export function useDeleteOrganizationUsersMutation(
       });
     },
     onError: (error) => {
-      console.error('멤버 일괄 삭제 실패', error);
+      //console.error('멤버 일괄 삭제 실패', error);
     },
   });
 }

--- a/apps/web/src/store/mutation/useUpdateOrganizationRoleMutation.ts
+++ b/apps/web/src/store/mutation/useUpdateOrganizationRoleMutation.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useUpdateOrganizationRoleMutation.ts
 import {
   useMutation,
   useQueryClient,
@@ -38,16 +37,16 @@ export function useUpdateOrganizationRoleMutation(
         `api/v1/organizations/${organizationId}/roles/${roleId}`,
         payload
       );
-      console.log('역할 수정 요청 완료:', { roleId, label, color });
+      //console.log('역할 수정 요청 완료:', { roleId, label, color });
     },
     onSuccess: (_data, variables) => {
-      console.log('역할 수정 성공:', variables);
+      //console.log('역할 수정 성공:', variables);
       qc.invalidateQueries({
         queryKey: queryKeys.organization.roles.list(organizationId),
       });
     },
     onError: (error, variables) => {
-      console.error('역할 수정 실패:', variables, error);
+      //console.error('역할 수정 실패:', variables, error);
     },
   });
 }

--- a/apps/web/src/store/mutation/useUpdateOrganizationRoleMutation.ts
+++ b/apps/web/src/store/mutation/useUpdateOrganizationRoleMutation.ts
@@ -1,0 +1,53 @@
+// src/store/organization/useUpdateOrganizationRoleMutation.ts
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { PATCH } from '@web/api/fetch';
+import { queryKeys } from '../constants';
+import type { PaletteColor } from '@repo/utils';
+import { hexToName } from '@web/utils/color';
+
+interface UpdateRoleRequest {
+  name: string;
+  color: string;
+}
+
+type Variables = {
+  roleId: number;
+  label: string;
+  color: PaletteColor;
+};
+
+/**
+ * 조직 역할 수정
+ */
+export function useUpdateOrganizationRoleMutation(
+  organizationId: number
+): UseMutationResult<void, Error, Variables, unknown> {
+  const qc = useQueryClient();
+
+  return useMutation<void, Error, Variables, unknown>({
+    mutationFn: async ({ roleId, label, color }) => {
+      const payload: UpdateRoleRequest = {
+        name: label,
+        color: hexToName[color]!,
+      };
+      await PATCH(
+        `api/v1/organizations/${organizationId}/roles/${roleId}`,
+        payload
+      );
+      console.log('역할 수정 요청 완료:', { roleId, label, color });
+    },
+    onSuccess: (_data, variables) => {
+      console.log('역할 수정 성공:', variables);
+      qc.invalidateQueries({
+        queryKey: queryKeys.organization.roles.list(organizationId),
+      });
+    },
+    onError: (error, variables) => {
+      console.error('역할 수정 실패:', variables, error);
+    },
+  });
+}

--- a/apps/web/src/store/query/useOrganizationMembersQuery.ts
+++ b/apps/web/src/store/query/useOrganizationMembersQuery.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useOrganizationMembersQuery.ts
 import { GET } from '@web/api/fetch';
 import {
   useSuspenseQuery,
@@ -11,8 +10,8 @@ import type { Tokens } from '@web/api/types';
 import { queryKeys } from '../constants';
 import type { PaginatedUsers } from '@web/types/organization';
 
-const STALE_TIME = 1000 * 60 * 2; // 2분
-const GC_TIME = 1000 * 60 * 3; // 3분
+const STALE_TIME = 1000 * 60 * 2;
+const GC_TIME = 1000 * 60 * 3;
 
 export type GetOrganizationMembersParams = {
   organizationId: number;
@@ -43,15 +42,13 @@ export function getOrganizationMembersQueryOptions({
   const key = queryKeys.organization.members.list(organizationId, page, size);
 
   const queryFn: OrganizationMembersQueryFn = async () => {
-    // 여기에 PaginatedUsers 를 직접 제네릭으로 넘겨 주면,
-    // GET<PaginatedUsers> ➞ ApiResponse<PaginatedUsers>
     const res = await GET<PaginatedUsers>(
       `api/v1/organizations/${organizationId}/users`,
       { page: String(page), size: String(size) },
       tokens
     );
     console.log('멤버 리스트 조회', res);
-    return res.result; // ✔ PaginatedUsers
+    return res.result;
   };
 
   return {
@@ -59,7 +56,6 @@ export function getOrganizationMembersQueryOptions({
     queryFn,
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
-    // 필요하다면 enabled: page > 0 처럼 조건도 추가할 수 있습니다.
   };
 }
 
@@ -78,7 +74,6 @@ export function useOrganizationMembersQuery(
     size,
     tokens,
   });
-  // 네 번째 타입 파라미터로 key 타입을 넘겨 줍니다
   return useSuspenseQuery<
     PaginatedUsers,
     unknown,

--- a/apps/web/src/store/query/useOrganizationMembersQuery.ts
+++ b/apps/web/src/store/query/useOrganizationMembersQuery.ts
@@ -1,0 +1,88 @@
+// src/store/organization/useOrganizationMembersQuery.ts
+import { GET } from '@web/api/fetch';
+import {
+  useSuspenseQuery,
+  type UseSuspenseQueryOptions,
+  type UseSuspenseQueryResult,
+  type QueryFunction,
+  type QueryKey,
+} from '@tanstack/react-query';
+import type { Tokens } from '@web/api/types';
+import { queryKeys } from '../constants';
+import type { PaginatedUsers } from '@web/types/organization';
+
+const STALE_TIME = 1000 * 60 * 2; // 2분
+const GC_TIME = 1000 * 60 * 3; // 3분
+
+export type GetOrganizationMembersParams = {
+  organizationId: number;
+  page: number;
+  size: number;
+  tokens?: Tokens;
+};
+export type OrganizationMembersQueryKey = QueryKey;
+export type OrganizationMembersQueryFn = QueryFunction<
+  PaginatedUsers,
+  OrganizationMembersQueryKey
+>;
+
+/**
+ * 서버/SSR 단계 혹은 Suspense 경계에서 미리 호출할 옵션
+ */
+export function getOrganizationMembersQueryOptions({
+  organizationId,
+  page,
+  size,
+  tokens,
+}: GetOrganizationMembersParams): UseSuspenseQueryOptions<
+  PaginatedUsers,
+  unknown,
+  PaginatedUsers,
+  OrganizationMembersQueryKey
+> {
+  const key = queryKeys.organization.members.list(organizationId, page, size);
+
+  const queryFn: OrganizationMembersQueryFn = async () => {
+    // 여기에 PaginatedUsers 를 직접 제네릭으로 넘겨 주면,
+    // GET<PaginatedUsers> ➞ ApiResponse<PaginatedUsers>
+    const res = await GET<PaginatedUsers>(
+      `api/v1/organizations/${organizationId}/users`,
+      { page: String(page), size: String(size) },
+      tokens
+    );
+    console.log('멤버 리스트 조회', res);
+    return res.result; // ✔ PaginatedUsers
+  };
+
+  return {
+    queryKey: key,
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    // 필요하다면 enabled: page > 0 처럼 조건도 추가할 수 있습니다.
+  };
+}
+
+/**
+ * 클라이언트 컴포넌트에서 Suspense로 바로 쓰는 훅
+ */
+export function useOrganizationMembersQuery(
+  organizationId: number,
+  page: number,
+  size: number,
+  tokens?: Tokens
+): UseSuspenseQueryResult<PaginatedUsers, unknown> {
+  const options = getOrganizationMembersQueryOptions({
+    organizationId,
+    page,
+    size,
+    tokens,
+  });
+  // 네 번째 타입 파라미터로 key 타입을 넘겨 줍니다
+  return useSuspenseQuery<
+    PaginatedUsers,
+    unknown,
+    PaginatedUsers,
+    typeof options.queryKey
+  >(options);
+}

--- a/apps/web/src/store/query/useOrganizationRolesQuery.ts
+++ b/apps/web/src/store/query/useOrganizationRolesQuery.ts
@@ -1,0 +1,80 @@
+// src/store/organization/useOrganizationRolesQuery.ts
+import { GET } from '@web/api/fetch';
+import {
+  useSuspenseQuery,
+  type UseSuspenseQueryOptions,
+  type UseSuspenseQueryResult,
+  type QueryFunction,
+  type QueryKey,
+} from '@tanstack/react-query';
+import type { Tokens } from '@web/api/types';
+import { queryKeys } from '../constants';
+import type {
+  OrganizationRolesData,
+  OrganizationRolesResponse,
+} from '@web/types/organization';
+
+const STALE_TIME = 1000 * 60 * 2; // 2분
+const GC_TIME = 1000 * 60 * 3; // 3분
+
+export type GetOrganizationRolesParams = {
+  organizationId: number;
+  keyword?: string;
+  tokens?: Tokens;
+};
+
+export type OrganizationRolesQueryKey = QueryKey;
+
+export type OrganizationRolesQueryFn = QueryFunction<
+  OrganizationRolesData,
+  OrganizationRolesQueryKey
+>;
+
+/**
+ * 서버/SSR 단계에서 미리 조직 역할 데이터를 가져올 옵션
+ */
+export function getOrganizationRolesQueryOptions({
+  organizationId,
+  keyword,
+  tokens,
+}: GetOrganizationRolesParams): UseSuspenseQueryOptions<
+  OrganizationRolesData,
+  unknown,
+  OrganizationRolesData,
+  OrganizationRolesQueryKey
+> {
+  const key = queryKeys.organization.roles.list(organizationId, keyword);
+
+  const queryFn: OrganizationRolesQueryFn = async () => {
+    const res = await GET<OrganizationRolesResponse['result']>(
+      `api/v1/organizations/${organizationId}/roles`,
+      keyword ? { keyword } : undefined,
+      tokens
+    );
+    console.log('역할 조회', res);
+    return res.result;
+  };
+
+  return {
+    queryKey: key,
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  };
+}
+
+/**
+ * 클라이언트 컴포넌트에서 사용하는 Suspense-ready 훅
+ */
+export function useOrganizationRolesQuery(
+  organizationId: number,
+  keyword?: string
+): UseSuspenseQueryResult<OrganizationRolesData, unknown> {
+  const options = getOrganizationRolesQueryOptions({ organizationId, keyword });
+  return useSuspenseQuery<
+    OrganizationRolesData,
+    unknown,
+    OrganizationRolesData,
+    OrganizationRolesQueryKey
+  >(options);
+}

--- a/apps/web/src/store/query/useOrganizationRolesQuery.ts
+++ b/apps/web/src/store/query/useOrganizationRolesQuery.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useOrganizationRolesQuery.ts
 import { GET } from '@web/api/fetch';
 import {
   useSuspenseQuery,
@@ -14,8 +13,8 @@ import type {
   OrganizationRolesResponse,
 } from '@web/types/organization';
 
-const STALE_TIME = 1000 * 60 * 2; // 2분
-const GC_TIME = 1000 * 60 * 3; // 3분
+const STALE_TIME = 1000 * 60 * 2;
+const GC_TIME = 1000 * 60 * 3;
 
 export type GetOrganizationRolesParams = {
   organizationId: number;
@@ -51,7 +50,7 @@ export function getOrganizationRolesQueryOptions({
       keyword ? { keyword } : undefined,
       tokens
     );
-    console.log('역할 조회', res);
+    //console.log('역할 조회', res);
     return res.result;
   };
 

--- a/apps/web/src/store/query/useOrganizationUsersQuery.ts
+++ b/apps/web/src/store/query/useOrganizationUsersQuery.ts
@@ -1,0 +1,47 @@
+// src/store/organization/useOrganizationUsersQuery.ts
+import { GET } from '@web/api/fetch';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import type { Tokens } from '@web/api/types';
+import type { UserResult } from '@web/types/organization';
+import { queryKeys } from '../constants';
+
+const STALE_TIME = 1000 * 60 * 1;
+const GC_TIME = 1000 * 60 * 2;
+
+/**
+ * 선택된 역할(roleId)이 0보다 클 때만 호출되는 운영진 조회 훅
+ */
+export function useOrganizationUsersQuery(
+  organizationId: number,
+  roleId: number,
+  keyword?: string,
+  tokens?: Tokens
+): UseQueryResult<UserResult[], unknown> {
+  // 1) 쿼리 키 생성
+  const key = queryKeys.organization.users.search(
+    organizationId,
+    roleId,
+    keyword
+  );
+
+  // 2) useQuery 에 옵션을 객체로 통째로 넘김
+  return useQuery<UserResult[]>({
+    queryKey: key,
+    queryFn: async () => {
+      const params: Record<string, string> = { roleId: String(roleId) };
+      if (keyword) params.keyword = keyword;
+
+      // prefixUrl 과 충돌 안 나도록 맨 앞 슬래시 제거
+      const res = await GET<UserResult[]>(
+        `api/v1/organizations/${organizationId}/users/search`,
+        params,
+        tokens
+      );
+      console.log('운영진 조회', res);
+      return res.result;
+    },
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    enabled: roleId > 0, // roleId 가 0일 땐 요청 자체가 일어나지 않습니다
+  });
+}

--- a/apps/web/src/store/query/useOrganizationUsersQuery.ts
+++ b/apps/web/src/store/query/useOrganizationUsersQuery.ts
@@ -1,4 +1,3 @@
-// src/store/organization/useOrganizationUsersQuery.ts
 import { GET } from '@web/api/fetch';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { Tokens } from '@web/api/types';
@@ -9,7 +8,7 @@ const STALE_TIME = 1000 * 60 * 1;
 const GC_TIME = 1000 * 60 * 2;
 
 /**
- * 선택된 역할(roleId)이 0보다 클 때만 호출되는 운영진 조회 훅
+ * 선택된 역할(roleId)이 0보다 클 때만 호출
  */
 export function useOrganizationUsersQuery(
   organizationId: number,
@@ -17,31 +16,28 @@ export function useOrganizationUsersQuery(
   keyword?: string,
   tokens?: Tokens
 ): UseQueryResult<UserResult[], unknown> {
-  // 1) 쿼리 키 생성
   const key = queryKeys.organization.users.search(
     organizationId,
     roleId,
     keyword
   );
 
-  // 2) useQuery 에 옵션을 객체로 통째로 넘김
   return useQuery<UserResult[]>({
     queryKey: key,
     queryFn: async () => {
       const params: Record<string, string> = { roleId: String(roleId) };
       if (keyword) params.keyword = keyword;
 
-      // prefixUrl 과 충돌 안 나도록 맨 앞 슬래시 제거
       const res = await GET<UserResult[]>(
         `api/v1/organizations/${organizationId}/users/search`,
         params,
         tokens
       );
-      console.log('운영진 조회', res);
+      //console.log('운영진 조회', res);
       return res.result;
     },
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
-    enabled: roleId > 0, // roleId 가 0일 땐 요청 자체가 일어나지 않습니다
+    enabled: roleId > 0,
   });
 }

--- a/apps/web/src/store/query/useUserByEmailQuery.ts
+++ b/apps/web/src/store/query/useUserByEmailQuery.ts
@@ -1,0 +1,21 @@
+import { GET } from '@web/api/fetch';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { EmailUser, EmailUserResponse } from '@web/types/organization';
+
+export function useUserByEmailQuery(
+  email: string,
+  enabled: boolean
+): UseQueryResult<EmailUser, Error> {
+  return useQuery<EmailUser, Error>({
+    queryKey: ['userByEmail', email],
+    queryFn: async () => {
+      const res = await GET<EmailUserResponse['result']>('api/v1/users/email', {
+        email,
+      });
+      return res.result;
+    },
+    enabled,
+    staleTime: 0,
+    gcTime: 0,
+  });
+}

--- a/apps/web/src/types/organization.ts
+++ b/apps/web/src/types/organization.ts
@@ -1,3 +1,30 @@
+/* api */
+import type { ApiResponse } from '@web/api/types';
+
+export interface RoleDto {
+  id: number;
+  roleName: string;
+  color: string; // 서버: 'blue', 'red' 등
+  assignedUserCount: number;
+}
+
+export interface OrganizationRolesData {
+  totalRoleCount: number;
+  roles: RoleDto[];
+}
+
+export type OrganizationRolesResponse = ApiResponse<OrganizationRolesData>;
+
+export interface CreateRoleRequest {
+  name: string;
+  color: string;
+}
+
+export type CreateRoleDto = Pick<RoleDto, 'id' | 'roleName' | 'color'>;
+
+export type CreateRoleResponse = ApiResponse<CreateRoleDto>;
+
+/* UI 에서 썼던거 */
 import { PaletteColor, TagColor } from '@repo/utils';
 
 export interface Role {
@@ -8,6 +35,10 @@ export interface Role {
 export interface RoleSelect {
   label: string;
   color: PaletteColor;
+}
+
+export interface RoleSelectWithCount extends RoleSelect {
+  count: number;
 }
 
 export interface Member {

--- a/apps/web/src/types/organization.ts
+++ b/apps/web/src/types/organization.ts
@@ -83,6 +83,15 @@ export interface AssignRoleRequest {
 
 export type AssignRoleResponse = ApiResponse<AssignUsersResult[]>;
 
+export interface EmailUser {
+  userId: number;
+  name: string;
+  email: string;
+  imageUrl: string | null;
+}
+
+export type EmailUserResponse = ApiResponse<EmailUser>;
+
 /* UI 에서 썼던거 */
 export interface OrgRole {
   id: number;

--- a/apps/web/src/types/organization.ts
+++ b/apps/web/src/types/organization.ts
@@ -1,6 +1,33 @@
 /* api */
 import type { ApiResponse } from '@web/api/types';
 
+export interface AssignUsersRequest {
+  userIds: number[];
+}
+
+export interface AssignUsersResult {
+  id: number;
+  userName: string;
+  roleName: string;
+}
+
+export type AssignUsersResponse = ApiResponse<AssignUsersResult[]>;
+
+export interface UserResult {
+  /** 사용자 고유 ID */
+  userId: number;
+  /** 이름 */
+  name: string;
+  /** 이메일 */
+  email: string;
+  /** 프로필 이미지 URL (없으면 null) */
+  imageUrl: string | null;
+  /** 해당 역할에 할당된 상태 */
+  isAssigned: boolean;
+}
+
+export type UserResponse = ApiResponse<UserResult[]>;
+
 export interface RoleDto {
   id: number;
   roleName: string;

--- a/apps/web/src/types/organization.ts
+++ b/apps/web/src/types/organization.ts
@@ -1,6 +1,8 @@
 /* api */
 import type { ApiResponse } from '@web/api/types';
 
+import { PaletteColor, TagColor } from '@repo/utils';
+
 export interface AssignUsersRequest {
   userIds: number[];
 }
@@ -51,8 +53,42 @@ export type CreateRoleDto = Pick<RoleDto, 'id' | 'roleName' | 'color'>;
 
 export type CreateRoleResponse = ApiResponse<CreateRoleDto>;
 
+export interface OrganizationUser {
+  userId: number;
+  profileImageUrl: string | null;
+  name: string;
+  email: string;
+  roles: { id: number; roleName: string; color: string }[];
+  gender: string;
+  birthDate: string;
+  phoneNumber: string;
+  createdAt: string;
+}
+
+export interface PaginatedUsers {
+  content: OrganizationUser[];
+  pageable: Record<string, unknown>;
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+export type PaginatedUsersResponse = ApiResponse<PaginatedUsers>;
+
+export interface AssignRoleRequest {
+  userId: number;
+  roleIds: number[];
+}
+
+export type AssignRoleResponse = ApiResponse<AssignUsersResult[]>;
+
 /* UI 에서 썼던거 */
-import { PaletteColor, TagColor } from '@repo/utils';
+export interface OrgRole {
+  id: number;
+  label: string;
+  color: TagColor;
+}
 
 export interface Role {
   label: string;

--- a/apps/web/src/utils/color.ts
+++ b/apps/web/src/utils/color.ts
@@ -1,0 +1,15 @@
+export const hexToName: Record<string, string> = {
+  '#FF5360': 'red',
+  '#FF995A': 'orange',
+  '#FFD062': 'yellow',
+  '#5BDF87': 'green',
+  '#86DAF9': 'bluesky',
+  '#6289FF': 'blue',
+  '#AD90FF': 'purple',
+  '#F196F8': 'pink',
+  '#C4C6D4': 'gray',
+  '#A9ABC0': 'darkgray',
+};
+export const nameToHex = Object.fromEntries(
+  Object.entries(hexToName).map(([hex, name]) => [name, hex])
+) as Record<string, string>;

--- a/apps/web/src/utils/color.ts
+++ b/apps/web/src/utils/color.ts
@@ -13,3 +13,29 @@ export const hexToName: Record<string, string> = {
 export const nameToHex = Object.fromEntries(
   Object.entries(hexToName).map(([hex, name]) => [name, hex])
 ) as Record<string, string>;
+
+// ——— 태그용 (OrgListItem 의 Tag) ———
+export const tagHexToName = {
+  '#FF2A3A': 'red',
+  '#EE6B00': 'orange',
+  '#E2A500': 'yellow',
+  '#009857': 'green',
+  '#0084BC': 'bluesky',
+  '#2C60FF': 'blue',
+  '#813DFF': 'purple',
+  '#F25DEB': 'pink',
+  '#7F82A1': 'gray',
+  '#5A5C72': 'darkgray',
+} as const;
+export type TagHex = keyof typeof tagHexToName; // '#FF2A3A' | …
+export type TagColorName = (typeof tagHexToName)[TagHex]; // 'red' | …
+export const nameToTagHex: Record<TagColorName, TagHex> = Object.fromEntries(
+  (Object.entries(tagHexToName) as [TagHex, TagColorName][]).map(
+    ([hex, name]) => [name, hex]
+  )
+) as Record<TagColorName, TagHex>;
+
+/** 서버 colorName → 태그 헥스 */
+export function mapServerColorToTagHex(name: string): TagHex {
+  return nameToTagHex[name as TagColorName] ?? '#7F82A1';
+}

--- a/packages/ui/src/components/DropDown/SelectDropdown/RolesDropdown.tsx
+++ b/packages/ui/src/components/DropDown/SelectDropdown/RolesDropdown.tsx
@@ -7,14 +7,15 @@ import { TagColor } from '@repo/utils';
 import RolesDropdownTriggerContent from './RolesDropdownTriggerContent';
 import { rolesDropdwon } from '../Dropdown.css';
 
-export interface Role {
+export interface OrgRole {
+  id: number;
   label: string;
   color: TagColor;
 }
 
 interface Props {
-  availableRoles: Role[];
-  onSelect: (role: Role) => void;
+  availableRoles: OrgRole[];
+  onSelect: (role: OrgRole) => void;
 }
 
 export default function RolesDropdown({ availableRoles, onSelect }: Props) {

--- a/packages/ui/src/components/Input/InputField.tsx
+++ b/packages/ui/src/components/Input/InputField.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import BaseInput from './BaseInput';
-import type { ReactNode, ChangeEvent } from 'react';
+import type { ReactNode, ChangeEvent, KeyboardEvent } from 'react';
 
 interface InputFieldProps {
   placeholder?: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   icon?: ReactNode;
   size?: 'search' | 'club' | 'auth';
   width?: string;
@@ -20,6 +21,7 @@ const InputField = ({
   placeholder,
   value,
   onChange,
+  onKeyDown,
   icon,
   size = 'search',
   width,
@@ -31,6 +33,7 @@ const InputField = ({
       inputProps={{
         value,
         onChange,
+        onKeyDown,
         placeholder,
         readOnly,
         onClick,

--- a/packages/ui/src/components/Profile/Profile.css.ts
+++ b/packages/ui/src/components/Profile/Profile.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@repo/theme';
 
 export const profileWrapper = style({
   display: 'flex',
@@ -14,4 +15,12 @@ export const profileImage = style({
   height: '100%',
   borderRadius: '50%',
   objectFit: 'cover',
+});
+
+export const emptyProfile = style({
+  width: '100%',
+  height: '100%',
+  borderRadius: '50%',
+  objectFit: 'cover',
+  backgroundColor: vars.colors.grayscale20,
 });

--- a/packages/ui/src/components/Profile/Profile.tsx
+++ b/packages/ui/src/components/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import * as styles from './Profile.css';
 
 interface ProfileProps {
-  src: string;
+  src?: string | null;
   alt: string;
   size?: number | string;
 }
@@ -14,7 +14,13 @@ export const Profile = ({ src, alt, size = 24 }: ProfileProps) => {
       className={styles.profileWrapper}
       style={{ width: dimension, height: dimension }}
     >
-      <img src={src} alt={alt} className={styles.profileImage} />
+      {src ? (
+        <img src={src} alt={alt} className={styles.profileImage} />
+      ) : (
+        // src가 없을 때는 <img>를 렌더링하지 않고 빈 div만 두거나
+        // 기본 아이콘/플레이스홀더를 넣으세요
+        <div className={styles.emptyProfile} />
+      )}
     </div>
   );
 };

--- a/packages/utils/src/hooks/useDebounce.ts
+++ b/packages/utils/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const h = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(h);
+  }, [value, delay]);
+  return debounced;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,7 +3,14 @@ export { mergeRefs } from './util/mergeRefs';
 export { useOutsideClick } from './hooks/useOutsideClick';
 export { useOverlay } from './hooks/useOverlay';
 export { getTabLabel } from './util/tab';
-export { isAfterMonth, isDateDisabled, isDateToday, isDateSelected, getDayVariant, generateCalendarData } from './util/datePicker';
+export {
+  isAfterMonth,
+  isDateDisabled,
+  isDateToday,
+  isDateSelected,
+  getDayVariant,
+  generateCalendarData,
+} from './util/datePicker';
 export type { TagColor } from './util/tag';
 export { tagColorMap } from './util/tag';
 export { getTagColors } from './util/tag';


### PR DESCRIPTION
## 이슈 넘버
- close #33
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
1.5차 api 연동 완료

## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
`useUserByEmailQuery` : 이메일이 정확히 일치하는 단일 사용자를 조회
`useOrganizationUsersQuery` : 특정 역할에 “할당된(isAssigned)” 여부를 포함한 운영진 목록 조회
`useOrganizationRolesQuery` : 조직의 역할(롤) 리스트 조회
`useOrganizationMembersQuery` : 페이징된 조직 사용자(운영진 포함) 전체 목록 조회
`useDeleteOrganizationUsersMutation` : 선택된 사용자들을 조직에서 일괄 삭제
`useAssignOrganizationUsersMutation` : 특정 롤에 여러 사용자를 한 번에 할당/제외
`useAssignRoleToUserMutation` : 단일 사용자에게 롤을 추가로 부여
`useAddOrganizationRoleMutation` : POST /roles 로 새 역할 생성
`useUpdateOrganizationRoleMutation` : PATCH /roles/{roleId} 로 기존 롤 수정


```tsx
import { getOrganizationRolesQueryOptions } from '@web/store/query/useOrganizationRolesQuery';
import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
import Settings from './Settings';
import { getServerSideTokens } from '@web/api/serverSideTokens';

export default async function Page() {
  const tokens = await getServerSideTokens();
  // 추후에 전역상태관리 사용해서 변환하기!!
  const organizationId = 3;

  const fetchOptions = [
    getOrganizationRolesQueryOptions({ organizationId, tokens }),
  ];

  return (
    <ServerFetchBoundary fetchOptions={fetchOptions}>
      <Settings organizationId={organizationId} />
    </ServerFetchBoundary>
  );
}
```
Page 컴포넌트: ServerFetchBoundary를 이용한 Suspense 사전 페칭

ServerFetchBoundary
- 서버 렌더링 단계에서 queryClient.fetchQuery(option)을 실행해 두 쿼리 데이터를 미리 가져오고,
- dehydrate(queryClient)로 캐시 상태를 직렬화해 클라이언트로 전달.
- 클라이언트는 HydrationBoundary 안에서 바로 이 캐시를 읽어, 첫 렌더 시 네트워크 요청 없이 즉시 데이터를 사용할 수 있음

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
