### PR TITLE
[feat] 2차 스프린트 지원서 부분 및 조직 역할 삭제 api 연동

### DIFF
--- a/apps/web/src/app/(main)/application-list/setting/@modal/(.)part/page.css.ts
+++ b/apps/web/src/app/(main)/application-list/setting/@modal/(.)part/page.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const tightRight = style({
+  marginRight: '-1.8rem',
+  boxSizing: 'border-box',
+});

--- a/apps/web/src/app/(main)/application-list/setting/@modal/(.)part/page.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/@modal/(.)part/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Modal } from '@repo/ui/Modal';
+import { SettingContext } from '../../_context/SettingContext';
+import { getClientSideTokens } from '@web/utils/getClientSideTokens';
+import { useOrganizationRolesQuery } from '@web/store/query/useOrganizationRolesQuery';
+import { PartContent } from '../../_components/PartModal/PartContent';
+import * as styles from './page.css';
+
+function arraysEqual(a: number[], b: number[]) {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+export default function PartModal() {
+  const router = useRouter();
+  const close = () => router.back();
+
+  const ctx = useContext(SettingContext)!;
+  const currentParts: string[] = ctx.form.applicationParts?.parts ?? [];
+
+  const { organizationId } = getClientSideTokens();
+  const { data: rolesData } = useOrganizationRolesQuery({ organizationId });
+
+  const allRoles = useMemo(
+    () =>
+      (rolesData?.roles ?? []).map((r) => ({
+        id: r.id,
+        roleName: r.roleName,
+        color: r.color,
+      })),
+    [rolesData]
+  );
+
+  const initialSelectedIds = useMemo(
+    () =>
+      allRoles
+        .filter((r) => currentParts.includes(r.roleName))
+        .map((r) => r.id),
+    [allRoles, currentParts]
+  );
+
+  const [selectedRoleIds, setSelectedRoleIds] = useState<number[]>(
+    () => initialSelectedIds
+  );
+
+  useEffect(() => {
+    setSelectedRoleIds((prev) =>
+      arraysEqual(prev, initialSelectedIds) ? prev : initialSelectedIds
+    );
+  }, [initialSelectedIds]);
+
+  const toggle = (roleId: number) => {
+    setSelectedRoleIds((prev) =>
+      prev.includes(roleId)
+        ? prev.filter((id) => id !== roleId)
+        : [...prev, roleId]
+    );
+  };
+
+  const confirm = () => {
+    const chosenNames = allRoles
+      .filter((r) => selectedRoleIds.includes(r.id))
+      .map((r) => r.roleName);
+
+    const unknown = currentParts.filter(
+      (p) => !allRoles.some((r) => r.roleName === p)
+    );
+    const nextParts = [...unknown, ...chosenNames];
+
+    ctx.setForm((prev) => ({
+      ...prev,
+      applicationParts: { isSelected: nextParts.length > 0, parts: nextParts },
+    }));
+
+    close();
+  };
+
+  return (
+    <Modal.Overlay open onClose={close}>
+      <Modal.Layout>
+        <Modal.Header text="파트 선택" />
+        <Modal.Content>
+          <div className={styles.tightRight}>
+            <PartContent
+              allRoles={allRoles}
+              selectedRoleIds={selectedRoleIds}
+              onToggle={toggle}
+            />
+          </div>
+        </Modal.Content>
+        <Modal.Footer hasTopBorder>
+          <Modal.DoubleCTA
+            cancelText="닫기"
+            cancelProps={{ onClick: close }}
+            confirmText="확인"
+            confirmProps={{ onClick: confirm }}
+          />
+        </Modal.Footer>
+      </Modal.Layout>
+    </Modal.Overlay>
+  );
+}

--- a/apps/web/src/app/(main)/application-list/setting/@modal/default.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultModal() {
+  return null;
+}

--- a/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/Item/DetailItemCard.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/Item/DetailItemCard.tsx
@@ -17,17 +17,20 @@ import { IcFileInfo } from '@repo/ui/icons/colored';
 import * as C from '@web/constants/application';
 import TypeControls from './TypeControls';
 import { vars } from '@repo/theme';
+import { IcCopy } from '@repo/ui/icons/mono';
 
 interface Props {
   index: number;
   onRemove: () => void;
   dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
+  onDuplicate: () => void;
 }
 
 export default function DetailItemCard({
   index,
   onRemove,
   dragHandleProps,
+  onDuplicate,
 }: Props) {
   const { control, setValue } = useFormContext();
 
@@ -99,7 +102,7 @@ export default function DetailItemCard({
             />
             {type === 'file' && (
               <Flex align="center" gap="0.2rem">
-                <IcFileInfo width={24} height={24} />
+                <IcFileInfo width={32} height={32} />
                 <Text variant="sm_caption_medium" color="grayscale30">
                   {C.UPLOAD_NOTICE}
                 </Text>
@@ -108,6 +111,15 @@ export default function DetailItemCard({
           </Flex>
 
           <Flex align="center" gap="1.2rem">
+            <button
+              type="button"
+              aria-label="항목 복제"
+              className={styles.iconButton}
+              onClick={onDuplicate}
+            >
+              <IcCopy width={32} height={32} />
+            </button>
+
             <button type="button" onClick={onRemove}>
               <Text variant="md1_text_semibold" color="grayscale40">
                 삭제

--- a/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/SectionDetailItems.css.ts
+++ b/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/SectionDetailItems.css.ts
@@ -83,11 +83,24 @@ export const dragHandle = style({
 
   ':active': { cursor: 'grabbing' },
 
-  // 부모(itemWrapper)를 hover하면 보이도록
   selectors: {
     [`${itemWrapper}:hover &`]: {
       opacity: 1,
       pointerEvents: 'auto',
+    },
+  },
+});
+
+export const iconButton = style({
+  color: vars.colors.grayscale20,
+  backgroundColor: 'transparent',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  transition: 'all 0.2s ease-in-out',
+  selectors: {
+    '&:hover': {
+      backgroundColor: vars.colors.grayscale5,
+      color: vars.colors.grayscale40,
     },
   },
 });

--- a/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/SectionDetailItems.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionDetailItems/SectionDetailItems.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFormContext, useFieldArray } from 'react-hook-form';
 import { Flex } from '@repo/ui/Flex';
 import { Text } from '@repo/ui/Text';
@@ -33,9 +33,15 @@ type SortableDetailItemProps = {
   id: string;
   index: number;
   onRemove: () => void;
+  onDuplicate: () => void;
 };
 
-function SortableDetailItem({ id, index, onRemove }: SortableDetailItemProps) {
+function SortableDetailItem({
+  id,
+  index,
+  onRemove,
+  onDuplicate,
+}: SortableDetailItemProps) {
   const {
     attributes,
     listeners,
@@ -61,14 +67,15 @@ function SortableDetailItem({ id, index, onRemove }: SortableDetailItemProps) {
         index={index}
         onRemove={onRemove}
         dragHandleProps={dragHandleProps}
+        onDuplicate={onDuplicate}
       />
     </div>
   );
 }
 
 export default function SectionDetailItems() {
-  const { control } = useFormContext();
-  const { fields, append, remove, move } = useFieldArray({
+  const { control, getValues } = useFormContext();
+  const { fields, append, remove, move, insert } = useFieldArray({
     name: 'detailItems',
     control,
   });
@@ -76,9 +83,19 @@ export default function SectionDetailItems() {
   // 터치/마우스 입력 모두 안정적으로 잡기 위한 sensor 설정
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: { distance: 6 }, // 약간 움직여야 드래그 시작 → 오작동 방지
+      activationConstraint: { distance: 6 },
     })
   );
+
+  const handleDuplicate = (index: number) => {
+    const all = getValues('detailItems') || [];
+    const target = all[index];
+    if (!target) return;
+
+    const cloned = JSON.parse(JSON.stringify(target));
+
+    insert(index + 1, cloned);
+  };
 
   const onDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -91,6 +108,22 @@ export default function SectionDetailItems() {
       move(oldIndex, newIndex); // RHF 필드 배열과 값이 함께 이동
     }
   };
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      append({
+        required: false,
+        type: 'text',
+        description: '',
+        addDescription: '',
+        responseTarget: 0,
+        typeInfo: {
+          info: C.BLANK_OPTIONS[0],
+          infoDetail: C.CHAR_LIMITS[2],
+        },
+      });
+    }
+  }, [fields.length, append]);
 
   return (
     <Flex direction="column" width="100%" align="flexStart" gap="1.6rem">
@@ -115,6 +148,7 @@ export default function SectionDetailItems() {
                 id={f.id}
                 index={idx}
                 onRemove={() => remove(idx)}
+                onDuplicate={() => handleDuplicate(idx)}
               />
             ))}
 

--- a/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionParts/SectionParts.css.ts
+++ b/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionParts/SectionParts.css.ts
@@ -1,9 +1,7 @@
-// app/application-list/setting/sections/SectionParts.css.ts
 import { style } from '@vanilla-extract/css';
 import { vars } from '@repo/theme';
 import { fontStyles } from '@repo/theme';
 
-// 파트 태그 기본 스타일
 export const tag = style({
   width: '21.2rem',
   height: '5.6rem',
@@ -19,15 +17,12 @@ export const tag = style({
   ...fontStyles.md2_text_regular,
 });
 
-// 파트 태그 비활성화 스타일
 export const tagDisabled = style({
   background: vars.colors.grayscale5,
   color: vars.colors.grayscale20,
   cursor: 'default',
 });
 
-// 추가 버튼 스타일
-// **비활성화된** 추가 버튼
 export const addButtonDisabled = style({
   display: 'flex',
   alignItems: 'center',
@@ -41,7 +36,6 @@ export const addButtonDisabled = style({
   cursor: 'not-allowed',
 });
 
-// **활성화된** 추가 버튼
 export const addButtonEnabled = style({
   display: 'flex',
   alignItems: 'center',
@@ -55,7 +49,6 @@ export const addButtonEnabled = style({
   cursor: 'pointer',
 });
 
-// 입력 컨테이너 스타일
 export const inputContainer = style({
   width: '21.2rem',
   height: '5.6rem',
@@ -66,7 +59,6 @@ export const inputContainer = style({
   background: vars.colors.white,
 });
 
-// 입력 필드 스타일
 export const input = style({
   display: 'flex',
   alignItems: 'center',

--- a/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionParts/SectionParts.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/_components/FormTab/SectionParts/SectionParts.tsx
@@ -1,52 +1,47 @@
-// src/web/app/(main)/application-list/setting/_components/FormTab/SectionParts.tsx
 'use client';
 
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import { Flex } from '@repo/ui/Flex';
 import { Text } from '@repo/ui/Text';
 import { Controller, useFormContext } from 'react-hook-form';
 import { SimpleToggleSwitch } from '@repo/ui/SimpleToggleSwitch';
-import { PartInput } from './Tag/PartInput';
 import { PartTag } from './Tag/PartTag';
 import { AddButton } from './Tag/AddButton';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { SettingContext } from '../../../_context/SettingContext';
 
 export default function SectionParts() {
   const { control, watch, setValue } = useFormContext();
+  const ctx = useContext(SettingContext)!;
   const enabled: boolean = watch('applicationParts.isSelected');
   const parts: string[] = watch('applicationParts.parts') || [];
 
-  const [isAdding, setIsAdding] = useState(false);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-  const handleConfirm = (newVal: string) => {
-    if (!newVal) return handleCancel();
-
-    if (editingIndex !== null) {
-      const next = [...parts];
-      next[editingIndex] = newVal;
-      setValue('applicationParts.parts', next);
-      setEditingIndex(null);
-    } else {
-      setValue('applicationParts.parts', [...parts, newVal]);
-      setIsAdding(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setIsAdding(false);
-    setEditingIndex(null);
+  const openPartModal = () => {
+    const qs = searchParams.toString();
+    router.push(`/application-list/setting/part${qs ? `?${qs}` : ''}`, {
+      scroll: false,
+    });
   };
 
   const handleRemove = (idx: number) => {
-    setValue(
-      'applicationParts.parts',
-      parts.filter((_, i) => i !== idx)
-    );
+    const next = parts.filter((_, i) => i !== idx);
+
+    setValue('applicationParts.parts', next, { shouldDirty: true });
+    setValue('applicationParts.isSelected', next.length > 0, {
+      shouldDirty: true,
+    });
+
+    ctx.setForm((prev) => ({
+      ...prev,
+      applicationParts: { isSelected: next.length > 0, parts: next },
+    }));
   };
 
   return (
     <Flex direction="column" gap="1.6rem" align="flexStart" width="100%">
-      {/* 토글 스위치 */}
       <Flex align="center" gap="1rem">
         <Text variant="md1_text_semibold" color="grayscale70">
           지원 파트
@@ -60,48 +55,19 @@ export default function SectionParts() {
         />
       </Flex>
 
-      {/* 파트 태그 및 입력, 추가 버튼 */}
+      {/* 파트 태그 + 추가 버튼 (인라인 입력 제거) */}
       <Flex wrap="wrap" gap="2.3rem" width="100%">
-        {/* 기존 파트 태그 */}
-        {parts.map((p, i) =>
-          editingIndex === i ? (
-            <PartInput
-              key={i}
-              defaultValue={p}
-              onConfirm={handleConfirm}
-              onCancel={handleCancel}
-            />
-          ) : (
-            <PartTag
-              key={i}
-              label={p}
-              onRemove={() => handleRemove(i)}
-              onEdit={() => {
-                setEditingIndex(i);
-                setIsAdding(false);
-              }}
-              disabled={!enabled}
-            />
-          )
-        )}
-
-        {/* 입력창: isAdding 상태일 때만 */}
-        {editingIndex === null && isAdding && (
-          <PartInput
-            defaultValue=""
-            onConfirm={handleConfirm}
-            onCancel={handleCancel}
+        {parts.map((p, i) => (
+          <PartTag
+            key={`${p}-${i}`}
+            label={p}
+            onRemove={() => handleRemove(i)}
+            onEdit={openPartModal}
+            disabled={!enabled}
           />
-        )}
+        ))}
 
-        {/* 항상 마지막에 추가 버튼 유지 */}
-        <AddButton
-          onClick={() => {
-            setIsAdding(true);
-            //setEditingIndex(null); // 추가할 땐 편집 아님
-          }}
-          disabled={!enabled}
-        />
+        <AddButton onClick={openPartModal} disabled={!enabled} />
       </Flex>
     </Flex>
   );

--- a/apps/web/src/app/(main)/application-list/setting/_components/PartModal/PartContent.css.ts
+++ b/apps/web/src/app/(main)/application-list/setting/_components/PartModal/PartContent.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@repo/theme';
+
+export const item = style({
+  borderBottom: `1px solid ${vars.colors.grayscale10}`,
+});
+
+export const listContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  height: '32.2rem',
+  maxHeight: '32.2rem',
+  overflowY: 'scroll',
+  paddingRight: '0.8rem',
+
+  scrollbarGutter: 'stable both-edges',
+
+  selectors: {
+    '&::-webkit-scrollbar': {
+      width: '4px',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: vars.colors.grayscale10,
+      borderRadius: '4px',
+    },
+    '&::-webkit-scrollbar-track': {
+      background: 'transparent',
+    },
+  },
+});

--- a/apps/web/src/app/(main)/application-list/setting/_components/PartModal/PartContent.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/_components/PartModal/PartContent.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { Flex } from '@repo/ui/Flex';
+import { CheckBox } from '@repo/ui/CheckBox';
+import { Tag } from '@repo/ui/Tag';
+import { mapServerColorToTagHex } from '@web/utils/color';
+import * as styles from './PartContent.css';
+
+interface SimpleRole {
+  id: number;
+  roleName: string;
+  color: string;
+}
+
+interface PartModalContentProps {
+  allRoles: SimpleRole[];
+  selectedRoleIds: number[];
+  onToggle: (roleId: number) => void;
+}
+
+export const PartContent = ({
+  allRoles,
+  selectedRoleIds,
+  onToggle,
+}: PartModalContentProps) => {
+  return (
+    <div className={styles.listContainer}>
+      {allRoles.map((role) => (
+        <Flex
+          key={role.id}
+          align="center"
+          gap="0.8rem"
+          width="100%"
+          justify="spaceBetween"
+          className={styles.item}
+          paddingBottom="1.7rem"
+          paddingTop="1.7rem"
+        >
+          <Tag withCircle color={mapServerColorToTagHex(role.color)}>
+            {role.roleName}
+          </Tag>
+          <CheckBox
+            isChecked={selectedRoleIds.includes(role.id)}
+            onChange={() => onToggle(role.id)}
+          />
+        </Flex>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/app/(main)/application-list/setting/_components/SettingForm/SettingForm.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/_components/SettingForm/SettingForm.tsx
@@ -1,7 +1,11 @@
 'use client';
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import { useForm, FormProvider, useWatch } from 'react-hook-form';
-import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import {
+  useSearchParams,
+  useRouter,
+  useSelectedLayoutSegments,
+} from 'next/navigation';
 import Link from 'next/link';
 import { Breadcrumb } from '@repo/ui/Breadcrumb';
 import { Button } from '@repo/ui/Button';
@@ -39,18 +43,20 @@ export function SettingForm({
   organization,
 }: SettingFormProps) {
   const scrollAreaRef = useRef<HTMLDivElement | null>(null);
-
   const didInitCriteria = useRef(false);
 
   const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
   const activeTab = (searchParams.get('tab') as TabKey) || 'form';
 
-  const lastSegment = pathname.split('/').pop();
-  const isNewPage = lastSegment === 'new';
+  const segs = useSelectedLayoutSegments();
+  const leaf = segs.at(-1) ?? 'new';
+  const isNewPage = leaf === 'new';
+  const hasIdParam = !!leaf && leaf !== 'new';
+  const recruitmentId = isNewPage ? null : Number(leaf);
+  const basePath = `/application-list/setting/${leaf}`;
+
   const isTemporaryParam = searchParams.get('isTemporary');
-  const hasIdParam = lastSegment != null && lastSegment !== 'new';
   const isTemporary = isTemporaryParam === 'true';
   const hasApplicantsParam = searchParams.get('hasApplicants');
   const hasApplicants = hasApplicantsParam === 'true';
@@ -59,7 +65,6 @@ export function SettingForm({
   const toast = useToast();
 
   const { organizationId } = getClientSideTokens();
-  //console.log('id', organizationId);
 
   const draftMutation = useDraftRecruitmentMutation();
   const publishMutation = usePublishRecruitmentMutation();
@@ -68,14 +73,13 @@ export function SettingForm({
   const customParts = initial.applicationParts?.isSelected
     ? initial.applicationParts.parts
     : [];
-  // 항상 공통(null) + 사용자 파트 순으로 섹션을 시딩
   const sections = customParts.length > 0 ? [...customParts] : [null];
 
   const seededPaperEvaluateItems =
     initial.paperEvaluateItems && initial.paperEvaluateItems.length > 0
       ? initial.paperEvaluateItems
       : sections.map((partName) => ({
-          positionName: partName, // part가 있으면 문자열들만, 없으면 null 1개
+          positionName: partName,
           items: [{ evaluate: '', evaluateDetail: '' }],
         }));
 
@@ -91,7 +95,6 @@ export function SettingForm({
     ...initial,
     paperEvaluateItems: seededPaperEvaluateItems,
     interviewEvaluateItems: seededInterviewEvaluateItems,
-
     detailItems:
       initial.detailItems && initial.detailItems.length > 0
         ? initial.detailItems
@@ -110,7 +113,7 @@ export function SettingForm({
           ],
   };
 
-  // 1. useForm 초기화 (Context에서 받은 초기값)
+  // 1) useForm 초기화
   const methods = useForm<FormValues>({
     defaultValues: seeded,
     mode: 'onChange',
@@ -118,14 +121,7 @@ export function SettingForm({
     shouldUnregister: false,
   });
 
-  console.log('폼', ctx.form);
-  /*useEffect(() => {
-    if (existentForm) {
-      const next = ctx.form;
-      methods.reset(next);
-    }
-  }, [ctx.form, methods]);*/
-
+  // 컨텍스트 → 폼 동기화
   useEffect(() => {
     methods.reset(ctx.form);
   }, [ctx.form, methods]);
@@ -146,9 +142,7 @@ export function SettingForm({
   // 서류 평가 기준 동기화
   useEffect(() => {
     const sectionNames = parts.length > 0 ? [...parts] : [null];
-
-    if (samePositions(paperItems, sectionNames)) return; // 변동 없으면 스킵
-
+    if (samePositions(paperItems, sectionNames)) return;
     const next = sectionNames.map((p) => {
       const existing = paperItems.find((sec) => sec.positionName === p);
       return {
@@ -158,16 +152,13 @@ export function SettingForm({
           : [{ evaluate: '', evaluateDetail: '' }],
       };
     });
-
     methods.setValue('paperEvaluateItems', next, { shouldValidate: false });
   }, [parts, paperItems, methods]);
 
   // 면접 평가 기준 동기화
   useEffect(() => {
     const sectionNames = parts.length > 0 ? [...parts] : [null];
-
-    if (samePositions(interviewItems, sectionNames)) return; // 변동 없으면 스킵
-
+    if (samePositions(interviewItems, sectionNames)) return;
     const next = sectionNames.map((p) => {
       const existing = interviewItems.find((sec) => sec.positionName === p);
       return {
@@ -177,7 +168,6 @@ export function SettingForm({
           : [{ evaluate: '', evaluateDetail: '' }],
       };
     });
-
     methods.setValue('interviewEvaluateItems', next, { shouldValidate: false });
   }, [parts, interviewItems, methods]);
 
@@ -187,15 +177,9 @@ export function SettingForm({
   const deadline = methods.watch('deadline')!;
   const interviewDuration = methods.watch('interviewDuration')!;
   const finalResultDate = methods.watch('finalResultDate')!;
-  //const paperItems = methods.watch('paperEvaluateItems')!;
-  //const interviewItems = methods.watch('interviewEvaluateItems')!;
-
-  const last = pathname.split('/').pop()!;
-  const recruitmentId = last === 'new' ? null : Number(last);
-
   const hasParts = methods.watch('applicationParts.isSelected') === true;
 
-  // 개별 검증
+  // 검증
   const isTitleOk = !!title.trim();
   const isBasicInfoOk = true;
   const isDetailItemsOk =
@@ -207,9 +191,7 @@ export function SettingForm({
   const isPaperOk =
     paperItems.length > 0 &&
     paperItems.every((section) => {
-      if (section.positionName === null && hasParts) {
-        return true; // 파트가 있으면 공통 무시
-      }
+      if (section.positionName === null && hasParts) return true; // 파트가 있으면 공통 무시
       return (
         section.items.length > 0 &&
         section.items.every((item) => item.evaluate.trim().length > 0)
@@ -218,16 +200,14 @@ export function SettingForm({
   const isInterviewOk =
     interviewItems.length > 0 &&
     interviewItems.every((section) => {
-      if (section.positionName === null && hasParts) {
-        return true; // 파트가 있으면 공통 무시
-      }
+      if (section.positionName === null && hasParts) return true;
       return (
         section.items.length > 0 &&
         section.items.every((item) => item.evaluate.trim().length > 0)
       );
     });
 
-  // 최종 버튼 활성 조건
+  // 최종 버튼 활성
   const canSubmit =
     isTitleOk &&
     isBasicInfoOk &&
@@ -238,24 +218,21 @@ export function SettingForm({
     isPaperOk &&
     isInterviewOk;
 
-  // 탭 & 버튼 핸들러
   const onTabChange = (tab: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('tab', tab);
-    router.replace(`${pathname}?${params.toString()}`);
-  };
-
-  const handlePreview = useCallback(() => {
     ctx.setForm(methods.getValues());
 
-    router.push(`${pathname}/preview`);
-  }, [ctx, methods, router, pathname]);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab);
+    router.replace(`${basePath}?${params.toString()}`);
+  };
+  const handlePreview = useCallback(() => {
+    ctx.setForm(methods.getValues());
+    router.push(`${basePath}/preview`);
+  }, [ctx, methods, router, basePath]);
 
   const handleCopyLink = useCallback(() => {
     if (!slug || !organization) return;
-
     const url = buildRecruitUrl(window.location.origin, organization, slug);
-
     navigator.clipboard
       .writeText(url)
       .then(() => toast.success('응답자에게 보낼 링크가 복제되었습니다.'))
@@ -265,31 +242,26 @@ export function SettingForm({
   const handleSave = useCallback(() => {
     const values = methods.getValues();
     const payload = convertFormToRequest(values, recruitmentId, organizationId);
-    //console.log('임시 저장:', payload);
     draftMutation.mutate(payload, {
-      onSuccess: (res) => {
-        /*if (pathname.endsWith('/new')) {
-          router.replace(`/application-list/setting/${res.recruitmentId}`);
-        }*/
+      onSuccess: () => {
         toast.success('임시 저장 되었습니다.');
       },
       onError: (err) => {
         console.error('임시 저장 실패', err);
       },
     });
-  }, [draftMutation, methods, pathname, router, recruitmentId]);
+  }, [draftMutation, methods, recruitmentId, organizationId, toast]);
 
   const onSubmit = useCallback(
     (data: FormValues) => {
       const payload = convertFormToRequest(data, recruitmentId, organizationId);
-      // console.log('최종 저장:', payload);
       publishMutation.mutate(payload, {
         onSuccess: () => {
           router.push('/application-list');
         },
       });
     },
-    [publishMutation, router, recruitmentId]
+    [publishMutation, router, recruitmentId, organizationId]
   );
 
   return (
@@ -370,9 +342,7 @@ export function SettingForm({
             onSubmit={methods.handleSubmit(onSubmit)}
             style={{ display: 'flex', width: '100%' }}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-              }
+              if (e.key === 'Enter') e.preventDefault();
             }}
           >
             {activeTab === 'form' && <FormTab />}

--- a/apps/web/src/app/(main)/application-list/setting/_context/SettingContext.ts
+++ b/apps/web/src/app/(main)/application-list/setting/_context/SettingContext.ts
@@ -5,7 +5,7 @@ import type { FormValues } from '@web/types/application';
 
 export interface SettingContextType {
   form: FormValues;
-  setForm: (f: FormValues) => void;
+  setForm: React.Dispatch<React.SetStateAction<FormValues>>;
 }
 
 export const SettingContext = createContext<SettingContextType | null>(null);

--- a/apps/web/src/app/(main)/application-list/setting/layout.tsx
+++ b/apps/web/src/app/(main)/application-list/setting/layout.tsx
@@ -28,12 +28,19 @@ const initialForm: FormValues = {
   interviewEvaluateItems: [],
 };
 
-export default function SettingLayout({ children }: { children: ReactNode }) {
+export default function SettingLayout({
+  children,
+  modal,
+}: {
+  children: ReactNode;
+  modal: ReactNode;
+}) {
   const [form, setForm] = useState<FormValues>(initialForm);
 
   return (
     <SettingContext.Provider value={{ form: form, setForm }}>
       {children}
+      {modal}
     </SettingContext.Provider>
   );
 }

--- a/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
+++ b/apps/web/src/app/(main)/organization/_components/RolePalettePanel/RolePalettePanel.tsx
@@ -12,6 +12,7 @@ import { RoleEditor } from './RoleEditor';
 import { RoleItem } from './RoleItem';
 import { mapServerColorToTagHex } from '@web/utils/color';
 import { useModal } from '@repo/ui/hooks';
+import { useDeleteOrganizationRoleMutation } from '@web/store/mutation/useDeleteOrganizationRoleMutation';
 
 export const COLOR_OPTIONS: PaletteColor[] = [
   '#FF5C6C',
@@ -40,7 +41,8 @@ export const colorHexToNameMap: Record<string, string> = {
 };
 
 interface Props {
-  roles: RoleSelectWithCount[];
+  organizationId: number;
+  roles: (RoleSelectWithCount & { id: number })[];
   search: string;
   selectedIdx: number | null;
   onSelectRole: (i: number) => void;
@@ -56,6 +58,7 @@ export default function RolePalettePanel({
   onSearchChange,
   onAddRole,
   onUpdateRole,
+  organizationId,
 }: Props) {
   const [isAdding, setIsAdding] = useState(false);
   const [newLabel, setNewLabel] = useState('');
@@ -66,6 +69,10 @@ export default function RolePalettePanel({
   const [editOpen, setEditOpen] = useState(false);
 
   const { confirm } = useModal();
+
+  //역할 삭제
+  const { mutateAsync: deleteRole, isPending: isDeleting } =
+    useDeleteOrganizationRoleMutation(organizationId);
 
   const handleAddKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && newLabel.trim()) {
@@ -84,15 +91,20 @@ export default function RolePalettePanel({
     }
   };
 
-  const handleDelete = (roleIdx: number, label: string) => {
+  const handleDelete = (roleId: number, label: string) => {
+    if (isDeleting) return;
     confirm({
       type: 'warning',
       title: '정말 삭제하시겠습니까?',
       description: `"${label}" 파트를 삭제하면 복구할 수 없습니다.`,
       cancelText: '취소',
       confirmText: '삭제',
-      onConfirm: () => {
-        // 역할 삭제 api 연동
+      onConfirm: async () => {
+        try {
+          await deleteRole(roleId);
+        } catch (e) {
+          console.error('역할 삭제 실패:', e);
+        }
       },
     });
   };
@@ -158,7 +170,7 @@ export default function RolePalettePanel({
                   setEditColor(r.color);
                   setEditOpen(false);
                 }}
-                onDelete={() => handleDelete(i, r.label)}
+                onDelete={() => handleDelete(r.id, r.label)}
               />
             );
           })}

--- a/apps/web/src/app/(main)/organization/settings/Settings.tsx
+++ b/apps/web/src/app/(main)/organization/settings/Settings.tsx
@@ -43,11 +43,14 @@ export default function Settings({ organizationId }: Props) {
       ),
     [rolesData.roles, roleSearch]
   );
-  const roleSelect: RoleSelectWithCount[] = filteredRoles.map((r) => ({
-    label: r.roleName,
-    color: nameToHex[r.color] as PaletteColor,
-    count: r.assignedUserCount,
-  }));
+  const roleSelect: (RoleSelectWithCount & { id: number })[] =
+    filteredRoles.map((r) => ({
+      id: r.id,
+      label: r.roleName,
+      color: nameToHex[r.color] as PaletteColor,
+      count: r.assignedUserCount,
+    }));
+
   const selectedRoleId =
     selectedRoleIdx != null ? filteredRoles[selectedRoleIdx]!.id : 0;
   const selectedRoleName =
@@ -120,6 +123,7 @@ export default function Settings({ organizationId }: Props) {
         <SettingsHeader onSave={handleSave} />
         <Flex align="center" gap="1.9rem" width="100%" marginTop="1.8rem">
           <RolePalettePanel
+            organizationId={organizationId}
             roles={roleSelect}
             search={roleSearch}
             selectedIdx={selectedRoleIdx}

--- a/apps/web/src/components/QuestionFileListForm/QuestionFileListForm.tsx
+++ b/apps/web/src/components/QuestionFileListForm/QuestionFileListForm.tsx
@@ -73,9 +73,41 @@ export const QuestionAndFileListForm = ({
                     </Text>
                   )}
                 </Flex>{' '}
+              </Flex>
+
+              <Flex width="100%" direction="column" gap="1rem">
+                <QuestionInput
+                  title={item.description}
+                  description={item.addDescription}
+                  infoDetail={item.typeInfo.infoDetail}
+                  value={
+                    readOnly
+                      ? ((item as any).answer ?? '')
+                      : (answers[textIndex] ?? '')
+                  }
+                  maxLength={maxLength as number | undefined}
+                  includeWhitespace={item.includeWhitespace}
+                  onFocus={status.setEditing}
+                  onChange={(val) => {
+                    if (readOnly) return;
+                    onAnswerChange(textIndex, val);
+                    status.setEditing();
+                  }}
+                  onBlur={(e) => {
+                    e.currentTarget.value.trim()
+                      ? status.setCompleted()
+                      : status.setDefault();
+                  }}
+                  readOnly={readOnly}
+                />
+
                 <Text
                   variant="sm_caption_medium"
-                  style={{ whiteSpace: 'nowrap' }}
+                  style={{
+                    whiteSpace: 'nowrap',
+                    textAlign: 'end',
+                    width: '100%',
+                  }}
                 >
                   {maxLength === undefined ? (
                     // 제한 없음인 경우
@@ -105,31 +137,6 @@ export const QuestionAndFileListForm = ({
                   )}
                 </Text>
               </Flex>
-
-              <QuestionInput
-                title={item.description}
-                description={item.addDescription}
-                infoDetail={item.typeInfo.infoDetail}
-                value={
-                  readOnly
-                    ? ((item as any).answer ?? '')
-                    : (answers[textIndex] ?? '')
-                }
-                maxLength={maxLength as number | undefined}
-                includeWhitespace={item.includeWhitespace}
-                onFocus={status.setEditing}
-                onChange={(val) => {
-                  if (readOnly) return;
-                  onAnswerChange(textIndex, val);
-                  status.setEditing();
-                }}
-                onBlur={(e) => {
-                  e.currentTarget.value.trim()
-                    ? status.setCompleted()
-                    : status.setDefault();
-                }}
-                readOnly={readOnly}
-              />
             </div>
           );
         }

--- a/apps/web/src/store/mutation/useDeleteOrganizationRoleMutation.ts
+++ b/apps/web/src/store/mutation/useDeleteOrganizationRoleMutation.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { DELETE } from '@web/api/fetch';
+
+export type DeleteOrganizationRoleResponse = {
+  code: number;
+  message: string;
+  result: string;
+  success: boolean;
+};
+
+/**
+ * 조직 역할 삭제
+ * DELETE /api/v1/organizations/{organizationId}/roles/{roleId}
+ */
+export function useDeleteOrganizationRoleMutation(organizationId: number) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (roleId: number) => {
+      const res = await DELETE<DeleteOrganizationRoleResponse>(
+        `api/v1/organizations/${organizationId}/roles/${roleId}`
+      );
+      return res.success;
+    },
+
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ['organization', organizationId, 'roles'],
+      });
+    },
+  });
+}


### PR DESCRIPTION
## 이슈 넘버
- close #181 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
상세항목 복제 - 구글폼처럼… 항목에 적은 내용들까지 그대로 복제되게
지원파트에서 조직관리에 있는 파트만 추가 가능하게
조직 역할 삭제 api 연동


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
딱히 없습니당!


## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
